### PR TITLE
Add action type for RTC message

### DIFF
--- a/extension/src/components/panel/RoomPanel.tsx
+++ b/extension/src/components/panel/RoomPanel.tsx
@@ -11,7 +11,7 @@ export const RoomPanel = () => {
       informations={Object.keys(informations)}
     >
       {Object.entries(informations).map(([id, info]) => (
-        <EditorTab key={id} id={id} displayHeader={id} {...JSON.parse(info)} />
+        <EditorTab key={id} id={id} displayHeader={id} {...info.code} />
       ))}
     </EditorProvider>
   );

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -88,3 +88,11 @@ interface EditorPreference {
 export interface ExtensionStorage {
   editorPreference: EditorPreference;
 }
+
+export interface PeerCodeMessage {
+  action: "code";
+  code: ServiceResponse["getValue"];
+  changes: string;
+}
+
+export type PeerMessage = PeerCodeMessage;


### PR DESCRIPTION
# Description

In preparation for #44, message passing between peers include an action to differentiate between different cases. I.e, instead of passing code directly, we now do

```ts
sendMessage(JSON.stringify({ action: "code", code: ... });
```
