### PR TITLE
Add local storage guard

### DIFF
--- a/extension/src/components/navigator/Navigator.tsx
+++ b/extension/src/components/navigator/Navigator.tsx
@@ -8,6 +8,7 @@ import { CaretRightIcon } from "@cb/components/icons";
 import UserDropdown from "@cb/components/navigator/dropdown/UserDropdown";
 import { AppState, appStateContext } from "@cb/context/AppStateProvider";
 import { usePeerSelection } from "@cb/hooks/index";
+import { getLocalStorage } from "@cb/services";
 
 export const RootNavigator = () => {
   const { state } = React.useContext(appStateContext);
@@ -62,10 +63,7 @@ export const RootNavigator = () => {
         {state === AppState.HOME && localStorage.getItem("curRoomId") && (
           <div className="absolute inset-0 h-full w-full flex justify-center items-center">
             <LoadingPanel
-              numberOfUsers={
-                JSON.parse(localStorage.getItem("curRoomId") || "{}")
-                  .numberOfUsers
-              }
+              numberOfUsers={getLocalStorage("curRoomId")?.numberOfUsers}
             />
           </div>
         )}

--- a/extension/src/components/navigator/menu/RoomControlMenu.tsx
+++ b/extension/src/components/navigator/menu/RoomControlMenu.tsx
@@ -11,6 +11,7 @@ import {
 import { AppState, appStateContext } from "@cb/context/AppStateProvider";
 import { useRTC } from "@cb/hooks/index";
 import { getQuestionIdFromUrl } from "@cb/utils";
+import { clearLocalStorage } from "@cb/services";
 
 interface MenuItem {
   display: string;
@@ -40,7 +41,8 @@ export const RoomControlMenu: React.FC<RoomControlMenuProps> = ({
           icon: <ResetIcon />,
           onClick: (e: React.MouseEvent<Element, MouseEvent>) => {
             e.stopPropagation();
-            localStorage.clear();
+            clearLocalStorage();
+            setDisplayMenu(false);
           },
         },
         {

--- a/extension/src/components/panel/AppPanel.tsx
+++ b/extension/src/components/panel/AppPanel.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { ResizableBox } from "react-resizable";
 import { useOnMount } from "@cb/hooks";
-import { getStorage, sendServiceRequest, setStorage } from "@cb/services";
+import {
+  getChromeStorage,
+  sendServiceRequest,
+  setChromeStorage,
+} from "@cb/services";
 import { ExtensionStorage } from "@cb/types";
 import { VerticalHandle } from "@cb/components/panel/Handle";
 import { CollapsedPanel } from "@cb/components/panel/CollapsedPanel";
@@ -19,7 +23,7 @@ export const AppPanel = (props: AppPanelProps) => {
   const minWidth = 40; // Set the minimum width threshold
 
   useOnMount(() => {
-    getStorage("appPreference").then(setAppPreference);
+    getChromeStorage("appPreference").then(setAppPreference);
   });
 
   return (
@@ -38,7 +42,7 @@ export const AppPanel = (props: AppPanelProps) => {
         })
       }
       onResizeStop={(_e, data) => {
-        setStorage({
+        setChromeStorage({
           appPreference: {
             ...appPreference,
             width: data.size.width,

--- a/extension/src/components/panel/editor/EditorPanel.tsx
+++ b/extension/src/components/panel/editor/EditorPanel.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { useOnMount, usePeerSelection } from "@cb/hooks/index";
-import { getStorage, sendServiceRequest, setStorage } from "@cb/services";
+import {
+  getChromeStorage,
+  sendServiceRequest,
+  setChromeStorage,
+} from "@cb/services";
 import { ResizableBox } from "react-resizable";
 import { ExtensionStorage } from "@cb/types";
 import { CodeBuddyPreference } from "@cb/constants";
@@ -31,7 +35,7 @@ const EditorPanel = () => {
   const activeTest = activePeer?.tests.find((test) => test.selected);
 
   useOnMount(() => {
-    getStorage("codePreference").then(setCodePreference);
+    getChromeStorage("codePreference").then(setCodePreference);
   });
 
   return (
@@ -87,7 +91,7 @@ const EditorPanel = () => {
               })
             }
             onResizeStop={(_e, data) => {
-              setStorage({
+              setChromeStorage({
                 codePreference: {
                   ...codePreference,
                   height: data.size.height,

--- a/extension/src/context/PeerSelectionProvider.tsx
+++ b/extension/src/context/PeerSelectionProvider.tsx
@@ -1,10 +1,15 @@
 import { EDITOR_NODE_ID } from "@cb/components/panel/editor/EditorPanel";
 import useInferTests from "@cb/hooks/useInferTests";
-import { sendServiceRequest } from "@cb/services";
+import {
+  getLocalStorage,
+  sendServiceRequest,
+  setLocalStorage,
+} from "@cb/services";
 import { waitForElement } from "@cb/utils";
 import React from "react";
 import { useOnMount, useRTC } from "../hooks";
 import { PeerInformation } from "./RTCProvider";
+import { Peer, TestCase } from "@cb/types";
 
 interface PeerSelectionContext {
   peers: Peer[];
@@ -21,23 +26,6 @@ interface PeerSelectionContext {
 export const PeerSelectionContext = React.createContext(
   {} as PeerSelectionContext
 );
-
-interface Assignment {
-  variable: string;
-  value: string;
-}
-
-interface TestCase {
-  selected: boolean;
-  test: Assignment[];
-}
-
-interface Peer {
-  id: string;
-  active: boolean;
-  viewable: boolean;
-  tests: TestCase[];
-}
 
 interface PeerSelectionProviderProps {
   children: React.ReactNode;
@@ -183,25 +171,16 @@ export const PeerSelectionProvider: React.FC<PeerSelectionProviderProps> = ({
   React.useEffect(() => {
     if (!loading) {
       console.log("Setting tabs", roomId, peers);
-      localStorage.setItem(
-        "tabs",
-        JSON.stringify({
-          roomId,
-          peers: peers,
-        })
-      );
+      setLocalStorage({ tabs: { roomId, peers } });
     }
   }, [peers, loading, roomId]);
 
   React.useEffect(() => {
-    const prevInfo: {
-      roomId: string;
-      peers: Peer[];
-    } = JSON.parse(localStorage.getItem("tabs") || "{}");
+    const prevInfo = getLocalStorage("tabs");
     setPeers((prev) =>
       Object.keys(informations).map((peerInfo) => {
-        const prevPeersTab = prevInfo.peers;
-        const prevRoomId = prevInfo.roomId;
+        const prevPeersTab = prevInfo?.peers ?? [];
+        const prevRoomId = prevInfo?.roomId;
         const peerTab = prev.find((peer) => peer.id === peerInfo) ?? {
           id: peerInfo,
           active: false,

--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -1,6 +1,11 @@
 import db from "@cb/db";
 import { useAppState, useOnMount } from "@cb/hooks";
-import { sendServiceRequest } from "@cb/services";
+import {
+  clearLocalStorage,
+  getLocalStorage,
+  sendServiceRequest,
+  setLocalStorage,
+} from "@cb/services";
 import {
   Payload,
   PeerCodeMessage,
@@ -181,13 +186,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
     // await db.usernamesCollection(roomRef.id).addUser(username);
     console.log("Created room");
     setRoomId(roomRef.id);
-    localStorage.setItem(
-      "curRoomId",
-      JSON.stringify({
-        roomId: roomRef.id,
-        numberOfUsers: 0,
-      })
-    );
+    setLocalStorage({ curRoomId: { roomId: roomRef.id, numberOfUsers: 0 } });
     navigator.clipboard.writeText(roomRef.id);
     toast.success(`Room ID ${roomRef.id} copied to clipboard`);
   };
@@ -343,10 +342,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
         });
       });
 
-      if (
-        JSON.parse(localStorage.getItem("curRoomId") ?? "{}").roomId !==
-        roomId.toString()
-      ) {
+      if (getLocalStorage("curRoomId")?.roomId !== roomId.toString()) {
         toast.success(
           `You have successfully joined the room with ID ${roomId}.`
         );
@@ -364,7 +360,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
       }
       if (!reload) {
         console.log("Cleaning up local storage");
-        localStorage.clear();
+        clearLocalStorage();
         sendServiceRequest({
           action: "cleanEditor",
         });
@@ -405,7 +401,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
   }, [roomId, username]);
 
   React.useEffect(() => {
-    const refreshInfo = JSON.parse(localStorage.getItem("curRoomId") ?? "{}");
+    const refreshInfo = getLocalStorage("curRoomId");
     if (refreshInfo && refreshInfo.roomId) {
       console.log("Reloading", refreshInfo);
       const prevRoomId = refreshInfo.roomId;
@@ -477,13 +473,9 @@ export const RTCProvider = (props: RTCProviderProps) => {
 
   React.useEffect(() => {
     if (roomId != null && informations) {
-      localStorage.setItem(
-        "curRoomId",
-        JSON.stringify({
-          roomId: roomId,
-          numberOfUsers: Object.keys(informations).length,
-        })
-      );
+      setLocalStorage({
+        curRoomId: { roomId, numberOfUsers: Object.keys(informations).length },
+      });
     }
   }, [roomId, informations]);
 

--- a/extension/src/services/background.ts
+++ b/extension/src/services/background.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { setStorage } from "@cb/services";
+import { setChromeStorage } from "@cb/services";
 import { ServiceRequest, Status, SetOtherEditorRequest } from "@cb/types";
 import { updateEditorLayout } from "@cb/services/handlers/editor";
 import { CodeBuddyPreference } from "@cb/constants";
@@ -35,7 +35,7 @@ const handleCookieRequest = async (): Promise<Status> => {
  */
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
-    setStorage({ ...CodeBuddyPreference });
+    setChromeStorage({ ...CodeBuddyPreference });
   }
 });
 

--- a/extension/src/services/index.ts
+++ b/extension/src/services/index.ts
@@ -1,13 +1,36 @@
-import { ExtensionStorage, ServiceRequest, ServiceResponse } from "@cb/types";
+import {
+  ExtensionStorage,
+  LocalStorage,
+  ServiceRequest,
+  ServiceResponse,
+} from "@cb/types";
+
+const LOCAL_STORAGE_KEY = "codebuddy";
 
 export const sendServiceRequest = <T extends ServiceRequest>(
   request: T
 ): Promise<ServiceResponse[T["action"]]> => chrome.runtime.sendMessage(request);
 
-export const setStorage = (items: Partial<ExtensionStorage>) =>
+export const setChromeStorage = (items: Partial<ExtensionStorage>) =>
   chrome.storage.sync.set(items);
 
-export const getStorage = <K extends keyof ExtensionStorage>(key: K) =>
+export const getChromeStorage = <K extends keyof ExtensionStorage>(key: K) =>
   chrome.storage.sync.get(key).then((pref) => pref[key]) as Promise<
     ExtensionStorage[K]
   >;
+
+export const getLocalStorage = <K extends keyof LocalStorage>(key: K) => {
+  const store = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "{}");
+  return store[key] as LocalStorage[K] | undefined;
+};
+
+export const setLocalStorage = (items: Partial<LocalStorage>) => {
+  const store = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "{}");
+  localStorage.setItem(
+    LOCAL_STORAGE_KEY,
+    JSON.stringify({ ...store, ...items })
+  );
+};
+
+export const clearLocalStorage = () =>
+  localStorage.removeItem(LOCAL_STORAGE_KEY);

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -88,9 +88,37 @@ interface CodePreference {
   height: number;
 }
 
+interface Assignment {
+  variable: string;
+  value: string;
+}
+
+export interface TestCase {
+  selected: boolean;
+  test: Assignment[];
+}
+
+export interface Peer {
+  id: string;
+  active: boolean;
+  viewable: boolean;
+  tests: TestCase[];
+}
+
 export interface ExtensionStorage {
   appPreference: AppPreference;
   codePreference: CodePreference;
+}
+
+export interface LocalStorage {
+  curRoomId: {
+    roomId: string;
+    numberOfUsers: number;
+  };
+  tabs: {
+    roomId: string | null;
+    peers: Peer[];
+  };
 }
 
 export interface PeerCodeMessage {


### PR DESCRIPTION
# Description

Previously, we use `localStorage.clear()`, which overrides Leetcode storage; as such, any user preference outside of the extension is lost.

I also took this chance to add an interface to `localStorage` usage, which will give us better typesafety too.