### PR TITLE
Refactor message types

### DIFF
--- a/extension/src/context/PeerSelectionProvider.tsx
+++ b/extension/src/context/PeerSelectionProvider.tsx
@@ -8,8 +8,7 @@ import {
 import { waitForElement } from "@cb/utils";
 import React from "react";
 import { useOnMount, useRTC } from "../hooks";
-import { PeerInformation } from "./RTCProvider";
-import { Peer, TestCase } from "@cb/types";
+import { Peer, PeerInformation, TestCase } from "@cb/types";
 
 interface PeerSelectionContext {
   peers: Peer[];
@@ -232,7 +231,7 @@ export const PeerSelectionProvider: React.FC<PeerSelectionProviderProps> = ({
     waitForElement(".monaco-editor", 2000)
       .then(() =>
         sendServiceRequest({
-          action: "createModel",
+          action: "setupCodeBuddyModel",
           id: EDITOR_NODE_ID,
         })
       )

--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -6,12 +6,7 @@ import {
   sendServiceRequest,
   setLocalStorage,
 } from "@cb/services";
-import {
-  Payload,
-  PeerCodeMessage,
-  PeerMessage,
-  PeerTestMessage,
-} from "@cb/types";
+import { PeerInformation, PeerMessage } from "@cb/types";
 import {
   constructUrlFromQuestionId,
   getQuestionIdFromUrl,
@@ -42,11 +37,6 @@ const servers = {
 };
 
 const CODE_MIRROR_CONTENT = ".cm-content";
-
-export interface PeerInformation {
-  code?: Payload<PeerCodeMessage>;
-  tests?: Payload<PeerTestMessage>;
-}
 
 export interface RTCContext {
   createRoom: (questionId: string) => void;

--- a/extension/src/services/background.ts
+++ b/extension/src/services/background.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { setChromeStorage } from "@cb/services";
-import { ServiceRequest, Status, SetOtherEditorRequest } from "@cb/types";
+import { ServiceRequest, Status, ExtractMessage } from "@cb/types";
 import { updateEditorLayout } from "@cb/services/handlers/editor";
 import { CodeBuddyPreference } from "@cb/constants";
 
@@ -97,7 +97,7 @@ const createModel = async (id: string) => {
 
 const setValueModel = async (
   args: Pick<
-    SetOtherEditorRequest,
+    ExtractMessage<ServiceRequest, "setValueOtherEditor">,
     "code" | "language" | "changes" | "changeUser" | "editorId"
   >
 ) => {
@@ -221,7 +221,7 @@ chrome.runtime.onMessage.addListener(
         break;
       }
 
-      case "createModel": {
+      case "setupCodeBuddyModel": {
         chrome.scripting
           .executeScript({
             target: { tabId: sender.tab?.id ?? 0 },
@@ -277,7 +277,7 @@ chrome.runtime.onMessage.addListener(
       }
 
       default:
-        // console.error(`Unhandled request ${request}`);
+        console.error(`Unhandled request ${request}`);
         break;
     }
 

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -1,83 +1,6 @@
-export interface User {
-  id: string;
-  username: string;
-}
-
-export type Status =
-  | {
-      status: "AUTHENTICATED";
-      user: User;
-    }
-  | { status: "LOADING" }
-  | { status: "UNAUTHENTICATED" };
-
-interface CookieRequest {
-  action: "cookie";
-}
-interface GetValueRequest {
-  action: "getValue";
-}
-
-interface SetValueRequest {
-  action: "setValue";
-  value: string;
-}
-
-interface CreateMonacoModelRequest {
-  action: "createModel";
-  id: string;
-}
-
-export interface SetOtherEditorRequest {
-  action: "setValueOtherEditor";
-  code: string;
-  language: string;
-  changes: {
-    range: {
-      startLineNumber: number;
-      startColumn: number;
-      endLineNumber: number;
-      endColumn: number;
-    };
-    rangeLength: number;
-    text: string;
-    rangeOffset: number;
-    forceMoveMarkers: boolean;
-  };
-  changeUser: boolean;
-  editorId: string;
-}
-
-interface UpdateEditorLayoutRequest {
-  action: "updateEditorLayout";
-  monacoEditorId: string;
-}
-
-interface CleanEditorRequest {
-  action: "cleanEditor";
-}
-
-export type ServiceRequest =
-  | CookieRequest
-  | GetValueRequest
-  | SetValueRequest
-  | CreateMonacoModelRequest
-  | SetOtherEditorRequest
-  | UpdateEditorLayoutRequest
-  | CleanEditorRequest;
-
-export type ServiceResponse = {
-  cookie: Status;
-  getValue: {
-    value: string;
-    language: string;
-  };
-  setValue: void;
-  createModel: void;
-  setValueOtherEditor: void;
-  updateEditorLayout: void;
-  cleanEditor: void;
-};
+export * from "./services";
+export * from "./peers";
+export type { MessagePayload, ExtractMessage } from "./utils";
 
 interface AppPreference {
   width: number;
@@ -120,18 +43,3 @@ export interface LocalStorage {
     peers: Peer[];
   };
 }
-
-export interface PeerCodeMessage {
-  action: "code";
-  code: ServiceResponse["getValue"];
-  changes: string;
-}
-
-export interface PeerTestMessage {
-  action: "tests";
-  tests: string[];
-}
-
-export type Payload<T> = Omit<T, "action">;
-
-export type PeerMessage = PeerCodeMessage | PeerTestMessage;

--- a/extension/src/types/peers.ts
+++ b/extension/src/types/peers.ts
@@ -1,0 +1,20 @@
+import type { ServiceResponse } from "./services";
+import { GenericMessage, MessagePayload } from "./utils";
+
+interface PeerCodeMessage extends GenericMessage {
+  action: "code";
+  code: ServiceResponse["getValue"];
+  changes: string;
+}
+
+interface PeerTestMessage extends GenericMessage {
+  action: "tests";
+  tests: string[];
+}
+
+export type PeerMessage = PeerCodeMessage | PeerTestMessage;
+
+export interface PeerInformation {
+  code?: MessagePayload<PeerCodeMessage>;
+  tests?: MessagePayload<PeerTestMessage>;
+}

--- a/extension/src/types/services.ts
+++ b/extension/src/types/services.ts
@@ -1,0 +1,86 @@
+import type { GenericMessage, GenericResponse } from "./utils";
+
+export interface User {
+  id: string;
+  username: string;
+}
+
+export type Status =
+  | {
+      status: "AUTHENTICATED";
+      user: User;
+    }
+  | { status: "LOADING" }
+  | { status: "UNAUTHENTICATED" };
+
+interface CookieRequest extends GenericMessage {
+  action: "cookie";
+}
+
+interface GetValueRequest extends GenericMessage {
+  action: "getValue";
+}
+
+interface SetValueRequest extends GenericMessage {
+  action: "setValue";
+  value: string;
+}
+
+interface SetupCodeBuddyModel extends GenericMessage {
+  action: "setupCodeBuddyModel";
+  id: string;
+}
+
+interface SetOtherEditorRequest extends GenericMessage {
+  action: "setValueOtherEditor";
+  code: string;
+  language: string;
+  changes: {
+    range: {
+      startLineNumber: number;
+      startColumn: number;
+      endLineNumber: number;
+      endColumn: number;
+    };
+    rangeLength: number;
+    text: string;
+    rangeOffset: number;
+    forceMoveMarkers: boolean;
+  };
+  changeUser: boolean;
+  editorId: string;
+}
+
+interface UpdateEditorLayoutRequest extends GenericMessage {
+  action: "updateEditorLayout";
+  monacoEditorId: string;
+}
+
+interface CleanEditorRequest extends GenericMessage {
+  action: "cleanEditor";
+}
+
+export type ServiceRequest =
+  | CookieRequest
+  | GetValueRequest
+  | SetValueRequest
+  | SetupCodeBuddyModel
+  | SetOtherEditorRequest
+  | UpdateEditorLayoutRequest
+  | CleanEditorRequest;
+
+export type ServiceResponse = GenericResponse<
+  ServiceRequest,
+  {
+    cookie: Status;
+    getValue: {
+      value: string;
+      language: string;
+    };
+    setValue: void;
+    setupCodeBuddyModel: void;
+    setValueOtherEditor: void;
+    updateEditorLayout: void;
+    cleanEditor: void;
+  }
+>;

--- a/extension/src/types/utils.ts
+++ b/extension/src/types/utils.ts
@@ -1,0 +1,17 @@
+export interface GenericMessage {
+  action: string;
+}
+
+export type GenericResponse<
+  T extends GenericMessage,
+  R extends Record<T["action"], unknown>
+> = {
+  [k in T["action"]]: R[k];
+};
+
+export type ExtractMessage<
+  T extends GenericMessage,
+  key extends T["action"]
+> = Extract<T, { action: key }>;
+
+export type MessagePayload<T extends GenericMessage> = Omit<T, "action">;


### PR DESCRIPTION
# Description

We have 2 types of messages currently:

1. content script 🤝 services
2. peer 🤝 peer

Soon, we'll have messages sent between windows. This PR breaks the different message types into their perspective files. Additionally, I've introduced a couple of utility types that we should all use - moving forward, I believe the convention should be to not arbitrary export any message type.

## Test

If `pnpm build` compiles, then we didn't miss anything.