### PR TITLE
Communicate content change directly

### DIFF
--- a/extension/src/components/panel/AppPanel.tsx
+++ b/extension/src/components/panel/AppPanel.tsx
@@ -61,7 +61,6 @@ export const AppPanel = (props: AppPanelProps) => {
           data-collapsed={appPreference.isCollapsed}
           className="h-full w-full data-[collapsed=true]:hidden"
         >
-          <div id="trackEditor" className="hidden" />
           {props.children}
         </div>
       </div>

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -1,6 +1,11 @@
 export * from "./services";
 export * from "./peers";
-export type { MessagePayload, ExtractMessage } from "./utils";
+export * from "./window";
+export type {
+  MessagePayload,
+  ExtractMessage,
+  LeetCodeContentChange,
+} from "./utils";
 
 interface AppPreference {
   width: number;

--- a/extension/src/types/services.ts
+++ b/extension/src/types/services.ts
@@ -1,4 +1,8 @@
-import type { GenericMessage, GenericResponse } from "./utils";
+import type {
+  GenericMessage,
+  GenericResponse,
+  LeetCodeContentChange,
+} from "./utils";
 
 export interface User {
   id: string;
@@ -31,22 +35,15 @@ interface SetupCodeBuddyModel extends GenericMessage {
   id: string;
 }
 
+interface SetupLeetCodeModel extends GenericMessage {
+  action: "setupLeetCodeModel";
+}
+
 interface SetOtherEditorRequest extends GenericMessage {
   action: "setValueOtherEditor";
   code: string;
   language: string;
-  changes: {
-    range: {
-      startLineNumber: number;
-      startColumn: number;
-      endLineNumber: number;
-      endColumn: number;
-    };
-    rangeLength: number;
-    text: string;
-    rangeOffset: number;
-    forceMoveMarkers: boolean;
-  };
+  changes: LeetCodeContentChange;
   changeUser: boolean;
   editorId: string;
 }
@@ -67,7 +64,8 @@ export type ServiceRequest =
   | SetupCodeBuddyModel
   | SetOtherEditorRequest
   | UpdateEditorLayoutRequest
-  | CleanEditorRequest;
+  | CleanEditorRequest
+  | SetupLeetCodeModel;
 
 export type ServiceResponse = GenericResponse<
   ServiceRequest,
@@ -79,6 +77,7 @@ export type ServiceResponse = GenericResponse<
     };
     setValue: void;
     setupCodeBuddyModel: void;
+    setupLeetCodeModel: void;
     setValueOtherEditor: void;
     updateEditorLayout: void;
     cleanEditor: void;

--- a/extension/src/types/utils.ts
+++ b/extension/src/types/utils.ts
@@ -15,3 +15,16 @@ export type ExtractMessage<
 > = Extract<T, { action: key }>;
 
 export type MessagePayload<T extends GenericMessage> = Omit<T, "action">;
+
+export interface LeetCodeContentChange {
+  range: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  };
+  rangeLength: number;
+  text: string;
+  rangeOffset: number;
+  forceMoveMarkers: boolean;
+}

--- a/extension/src/types/window.ts
+++ b/extension/src/types/window.ts
@@ -1,0 +1,8 @@
+import { LeetCodeContentChange } from "./utils";
+
+interface LeetCodeOnChangeMessage {
+  action: "leetCodeOnChange";
+  changes: LeetCodeContentChange;
+}
+
+export type WindowMessage = LeetCodeOnChangeMessage;


### PR DESCRIPTION
# Description

Prior to this PR, we communicate user's LeetCode editor changes by

1. Listening on `onDidChangeContent`
2. Serialize the change and write to a hidden div `#trackEditor`
3. Setup a DOM listener on `#trackEditor`

This workflow works, but is not ideal because writing to and observing the div element is slow - we can run into a race where before `sendCode` is applied with change A, another change B has been written to the div. When `sendCode` is executed, we send B and missed A.

This PR forwards the changes by communicating via `window.postMessage`. In the future, we'll setup a queue of changes to be forward.
