### PR TITLE
Send code and tests on channel open

### DIFF
--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -232,7 +232,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
     []
   );
 
-  const onOpen = (peer: string) => () => {
+  const onOpen = React.useRef((peer: string) => () => {
     console.log("Data Channel is open for " + peer);
     pcs.current[peer].lastSeen = getUnixTs();
     sendCodeRef.current({ peer, payload: undefined });
@@ -245,7 +245,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
         connected: true,
       },
     }));
-  };
+  });
 
   const onmessage = React.useCallback(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -315,7 +315,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
       };
 
       channel.onmessage = onmessage(peer);
-      channel.onopen = onOpen(peer);
+      channel.onopen = onOpen.current(peer);
 
       pc.onicecandidate = async (event) => {
         if (event.candidate) {
@@ -422,7 +422,7 @@ export const RTCProvider = (props: RTCProviderProps) => {
             pc.ondatachannel = (event) => {
               pcs.current[peer].channel = event.channel;
               pcs.current[peer].channel.onmessage = onmessage(peer);
-              pcs.current[peer].channel.onopen = onOpen(peer);
+              pcs.current[peer].channel.onopen = onOpen.current(peer);
             };
             pc.onicecandidate = async (event) => {
               if (event.candidate) {


### PR DESCRIPTION
# Description

Previously, we only needed `connected` state to send code to new users when they first join - the alternative to use `informations` meant that it would be too noisy. 

* Now, code and test cases are sent when the channel is opened, which means we don't need to send unnecessary information to other users.
* Consolidate usage of refs vs callbacks for messages - I don't think any of the `send[Action]` should be a callback actually.
