### PR TITLE
Parallelize dev mode

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -9,6 +9,7 @@
     "build": "pnpm run \"/^build:.*/\"",
     "dev:build": "pnpm run build --mode development",
     "dev": "pnpm run dev:build && concurrently --kill-others \"node script/dev.mjs\" \"pnpm run dev:build --watch\"",
+    "dev:1": "USERS=1 pnpm run dev",
     "dev:3": "USERS=3 pnpm run dev",
     "dev:4": "USERS=4 pnpm run dev"
   },

--- a/extension/script/dev.mjs
+++ b/extension/script/dev.mjs
@@ -57,9 +57,11 @@ const setup = async () => {
   });
   await Promise.all(asyncBrowsers);
 
-  // Waits for first person to create and setup room. Everyone else can join simultaneously
-  await setupRoom(PAGES[0].page, true);
-  await Promise.all(PAGES.slice(1).map(({ page }) => setupRoom(page, false)));
+  if (NUM_USERS > 1) {
+    // Waits for first person to create and setup room. Everyone else can join simultaneously
+    await setupRoom(PAGES[0].page, true);
+    await Promise.all(PAGES.slice(1).map(({ page }) => setupRoom(page, false)));
+  }
 };
 
 const reload = _.debounce(() => {

--- a/extension/src/hooks/useDevMode.ts
+++ b/extension/src/hooks/useDevMode.ts
@@ -8,10 +8,10 @@ const useDevMode = () => {
   const { createRoom, joinRoom, leaveRoom } = useRTC();
 
   useOnMount(() => {
+    if (import.meta.env.MODE !== "development") {
+      return;
+    }
     const unsafeResetRoom = async (roomId: string) => {
-      if (import.meta.env.MODE !== "development") {
-        throw new Error("Cannot reset room in production mode");
-      }
       await updateDoc(db.room(roomId).ref(), { usernames: [] });
     };
     const onWindowMessage = (message: MessageEvent) => {

--- a/extension/src/hooks/useSession.tsx
+++ b/extension/src/hooks/useSession.tsx
@@ -1,0 +1,4 @@
+enum AuthenticationStatus {
+  AUTHENTICATED,
+  UNAUTHENTICATED,
+}


### PR DESCRIPTION
# Description

* Previously, we spin up browsers one by one, which leads to slow start time
* Now the initial browsers are initialized "simultaneously", and the only thing we need to synchronize is the first person creating the room
* Additionally, took some time to setup the script so that we can choose dev mode between 2 to 4 users.

This is technically an extension to #43.
