### PR TITLE
Make bottom navigation visible

### DIFF
--- a/extension/src/components/navigator/AppNavigator.tsx
+++ b/extension/src/components/navigator/AppNavigator.tsx
@@ -76,7 +76,12 @@ export const AppNavigator = () => {
         </div>
         <EditorPanel />
       </div>
-      <div className="flex items-center w-full bg-[--color-tabset-tabbar-background] h-12 rounded-b-lg p-2 overflow-x-auto overflow-y-hidden text-sm self-end">
+      <div
+        className={cn(
+          "flex items-center w-full bg-[--color-tabset-tabbar-background] h-12 rounded-b-lg p-2 overflow-x-auto overflow-y-hidden text-sm self-end",
+          { hidden: peers.length === 0 }
+        )}
+      >
         {peers.map(({ id, active }) => (
           <React.Fragment key={id}>
             {/* Leetcode className flexlayout__tab_button_* */}

--- a/extension/src/components/panel/editor/EditorPanel.tsx
+++ b/extension/src/components/panel/editor/EditorPanel.tsx
@@ -77,7 +77,10 @@ const EditorPanel = () => {
               />
             </div>
           </ResizableBox>
-          <div className="w-full h-full overflow-auto">
+          <div
+            className="relative w-full overflow-auto"
+            style={{ height: height - codePreference.height - 128 }}
+          >
             <div className="mx-5 my-4 flex flex-col space-y-4">
               <div className="flex w-full flex-row items-start justify-between gap-4">
                 <div className="flex flex-nowrap items-center gap-x-2 gap-y-4 overflow-x-scroll hide-scrollbar">


### PR DESCRIPTION
# Description

* Bottom navigation is now visible on smaller height browser.
* Impose height on test cases, so that it's scrollable.

## Screenshots

![image](https://github.com/user-attachments/assets/68e4a265-fd6a-4d81-9e6d-b05b39832039)

![image](https://github.com/user-attachments/assets/60ed74c1-3c87-4149-9e91-a900ab23583b)
