### PR TITLE
Disable CORs on puppeteer

### DIFF
--- a/extension/script/dev.mjs
+++ b/extension/script/dev.mjs
@@ -25,6 +25,8 @@ const setup = async () => {
         `--disable-extensions-except=${EXTENSION_PATH}`,
         `--load-extension=${EXTENSION_PATH}`,
         "--start-maximized",
+        // todo(nickbar01234): Figure out nginx and ngrok so that cors doesn't break
+        "--disable-web-security",
       ],
       devtools: true,
     });


### PR DESCRIPTION
# Description

Pre-requisite to #131. We have docker running on http, but Leetcode is on https, meaning we won't be able to make any network requests. We've explored using ngrok and nginx as a reverse proxy in #138, but the solution there is much more long winded.