### PR TITLE
Close previous tab on initial signin

### DIFF
--- a/extension/src/App.tsx
+++ b/extension/src/App.tsx
@@ -2,10 +2,20 @@ import RootNavigator from "@cb/components/navigator/RootNavigator";
 import { AppPanel } from "@cb/components/panel";
 import SessionProvider from "./context/SessionProvider";
 import { WindowProvider } from "./context/WindowProvider";
+import { Toaster } from "sonner";
 
 const App = () => {
   return (
     <WindowProvider>
+      <Toaster
+        richColors
+        expand
+        closeButton
+        visibleToasts={5}
+        toastOptions={{
+          duration: 10 * 1000,
+        }}
+      />
       <AppPanel>
         <SessionProvider>
           <RootNavigator />

--- a/extension/src/components/navigator/AppNavigator.tsx
+++ b/extension/src/components/navigator/AppNavigator.tsx
@@ -8,7 +8,6 @@ import { usePeerSelection } from "@cb/hooks/index";
 import useDevSetupRoom from "@cb/hooks/useDevSetupRoom";
 import { getLocalStorage } from "@cb/services";
 import React from "react";
-import { Toaster } from "sonner";
 import { RejoinPrompt } from "./menu/RejoinPrompt";
 import { cn } from "@cb/utils/cn";
 import Header from "@cb/components/ui/Header";
@@ -27,15 +26,6 @@ export const AppNavigator = () => {
 
   return (
     <div className="h-full w-full relative flex flex-col">
-      <Toaster
-        richColors
-        expand
-        closeButton
-        visibleToasts={5}
-        toastOptions={{
-          duration: 10 * 1000,
-        }}
-      />
       <div className="flex justify-between items-center w-full bg-[--color-tabset-tabbar-background] h-9 rounded-t-lg p-2 overflow-y-hidden overflow-x-scroll hide-scrollbar gap-2">
         <div className="flex items-center">
           <Header />

--- a/extension/src/hooks/auth/useSignInWithEmailLink.tsx
+++ b/extension/src/hooks/auth/useSignInWithEmailLink.tsx
@@ -5,7 +5,7 @@ import {
   sendSignInLinkToEmail,
 } from "firebase/auth/web-extension";
 import { auth } from "@cb/db";
-import { setLocalStorage } from "@cb/services";
+import { sendServiceRequest, setLocalStorage } from "@cb/services";
 
 interface SignInInit {
   status: "INIT";
@@ -45,8 +45,12 @@ export const useSignInWithEmailLink = () => {
 
   const onEmailSubmit = () =>
     sendSignInLinkToEmail(auth, email, actionCodeSettings)
-      .then(() => {
-        setLocalStorage("email", email);
+      .then(async () => {
+        setLocalStorage("signIn", {
+          email,
+          url: actionCodeSettings.url,
+          tabId: await sendServiceRequest({ action: "getActiveTabId" }),
+        });
         setStatus({ status: "SENT" });
       })
       .catch((error: any) => {

--- a/extension/src/services/background.ts
+++ b/extension/src/services/background.ts
@@ -1,7 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CodeBuddyPreference } from "@cb/constants";
 import { setChromeStorage } from "@cb/services";
-import { ExtractMessage, ServiceRequest, WindowMessage } from "@cb/types";
+import {
+  ExtractMessage,
+  ResponseStatus,
+  ServiceRequest,
+  ServiceResponse,
+  WindowMessage,
+} from "@cb/types";
+
+const servicePayload = <T extends ServiceRequest["action"]>(
+  payload: ServiceResponse[T]
+) => payload;
 
 /**
  * Initialize default settings
@@ -96,10 +106,10 @@ const setupLeetCodeModel = async () => {
       .filter((e: any) => e.id !== "CodeBuddy")
       .map((e: any) => e.getModel())
       .find((m: any) => m.getLanguageId() !== "plaintext");
-      if (!leetCodeEditor) {
-        console.error("LeetCode editor model not found");
-        return { status: 1 };
-      }
+    if (!leetCodeEditor) {
+      console.error("LeetCode editor model not found");
+      return { status: 1 };
+    }
     leetCodeEditor.onDidChangeContent((event: any) => {
       // todo(nickbar01234): Don't have a good way to include function from a different file yet
       // Ideally, we should do the same pattern as services/index.ts
@@ -203,7 +213,6 @@ chrome.runtime.onMessage.addListener(
             world: "MAIN",
           })
           .then((result) => {
-            console.log(result);
             sendResponse(result[0].result);
           });
         break;
@@ -243,8 +252,31 @@ chrome.runtime.onMessage.addListener(
         break;
       }
 
-      case "reloadExtension": {
-        chrome.runtime.reload();
+      case "getActiveTabId": {
+        // Per https://developer.chrome.com/docs/extensions/develop/concepts/content-scripts, we don't have access to
+        // chrome API. So using background as a proxy
+        sendResponse(sender.tab?.id ?? -1);
+        break;
+      }
+
+      case "closeSignInTab": {
+        const {
+          signIn: { url, tabId },
+        } = request;
+        chrome.tabs
+          .get(tabId)
+          .then(async (tab) => {
+            const response = servicePayload<"closeSignInTab">({
+              status: tab.url?.startsWith(url)
+                ? ResponseStatus.SUCCESS
+                : ResponseStatus.FAIL,
+            });
+            if (response.status === ResponseStatus.SUCCESS) {
+              await chrome.tabs.remove(tabId);
+            }
+            sendResponse(response);
+          })
+          .catch(console.error);
         break;
       }
 

--- a/extension/src/services/index.ts
+++ b/extension/src/services/index.ts
@@ -7,7 +7,11 @@ import {
 
 const LOCAL_STORAGE_PREFIX = "codebuddy";
 // todo(nickbar01234): Need a more robust typescript solution
-const LOCAL_STORAGE: Array<keyof LocalStorage> = ["tabs", "lastActivePeer"];
+const LOCAL_STORAGE: Array<keyof LocalStorage> = [
+  "tabs",
+  "lastActivePeer",
+  "signIn",
+];
 
 export const sendServiceRequest = <T extends ServiceRequest>(
   request: T
@@ -29,7 +33,7 @@ export const getLocalStorage = <K extends keyof LocalStorage>(key: K) => {
 };
 
 export const removeLocalStorage = <K extends keyof LocalStorage>(key: K) => {
-  localStorage.removeItem(LOCAL_STORAGE + key);
+  localStorage.removeItem(LOCAL_STORAGE_PREFIX + key);
 };
 
 export const setLocalStorage = <K extends keyof LocalStorage>(

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -48,5 +48,9 @@ export interface LocalStorage {
     peer: string;
   };
   lastActivePeer: string;
-  email: string;
+  signIn: {
+    email: string;
+    url: string;
+    tabId: number;
+  };
 }

--- a/extension/src/types/services.ts
+++ b/extension/src/types/services.ts
@@ -1,3 +1,4 @@
+import { LocalStorage } from ".";
 import type {
   GenericMessage,
   GenericResponse,
@@ -35,13 +36,24 @@ interface ReloadExtensionRequest extends GenericMessage {
   action: "reloadExtension";
 }
 
+interface GetActiveTabIdRequest extends GenericMessage {
+  action: "getActiveTabId";
+}
+
+interface CloseSignInTabRequest extends GenericMessage {
+  action: "closeSignInTab";
+  signIn: LocalStorage["signIn"];
+}
+
 export type ServiceRequest =
   | GetValueRequest
   | PastCodeRequest
   | SetupCodeBuddyModel
   | SetOtherEditorRequest
   | SetupLeetCodeModel
-  | ReloadExtensionRequest;
+  | ReloadExtensionRequest
+  | GetActiveTabIdRequest
+  | CloseSignInTabRequest;
 
 export enum ResponseStatus {
   SUCCESS,
@@ -64,5 +76,7 @@ export type ServiceResponse = GenericResponse<
     setupLeetCodeModel: ServiceGenericResponse;
     setValueOtherEditor: void;
     reloadExtension: void;
+    getActiveTabId: number;
+    closeSignInTab: ServiceGenericResponse;
   }
 >;


### PR DESCRIPTION
# Description

Resolve #107. The flow at a high-level

1. On email link sent, we persist the current tab url and id.
2. When user clicks the sign-in email link, `background.ts` checks the url of the persisted tab id.
3. If the url of the persisted tab id matches the url stored, we close the tab. This is concious, as we don't want to close user tab if they navigated away from the question.

## Screenshots

https://github.com/user-attachments/assets/7262e58e-574a-4a9a-9375-ee4442c70ac7

## Test

- Sign in and see that the previous tab was closed
- Sign in, before clicking the link, navigate to a different page in the previous tab. After clicking on the link, the tab should not be closed.

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [X] Create room and join room on at least 2 browsers
- [X] Ensure that code and tests are correctly stream
- [X] Verify that when reloading, user can automatically join the room

## Possible Downsides

This flow might be annoying for end-user, but I think this is standard for a lot of web login flow?