### PR TITLE
Remove redundant bg-color

### DIFF
--- a/extension/src/components/navigator/dropdown/UserDropdown.tsx
+++ b/extension/src/components/navigator/dropdown/UserDropdown.tsx
@@ -64,7 +64,7 @@ const UserDropdown: React.FC<UserDropdownProps> = ({ isOpen, toggle }) => {
 
         <div
           className={cn(
-            "bg-layer-3 dark:bg-dark-layer-3 border-divider-4 dark:border-dark-divider-4 shadow-level1 dark:shadow-dark-level1 -transform-x-1/2 absolute z-50 w-44 divide-gray-100 rounded-lg shadow dark:bg-gray-700",
+            "bg-layer-3 dark:bg-dark-layer-3 border-divider-4 dark:border-dark-divider-4 shadow-level1 dark:shadow-dark-level1 -transform-x-1/2 absolute z-50 w-44 divide-gray-100 rounded-lg shadow",
             isOpen && peers.length >= 2 ? "block" : "hidden"
           )}
         >


### PR DESCRIPTION
# Description

In #149, we added [cn]([https://github.com/nickbar01234/codebuddy/pull/149/files#diff-4d7cfde89c6e8a7cd4389d705e63720727e42e474e8871c90b201b44e6c73545R67-R70](https://github.com/nickbar01234/codebuddy/pull/149/files?fbclid=IwZXh0bgNhZW0CMTAAAR2VGWvR179g2yS9Q7_VFLh6-k4fCuZtEJXlNuJSc2Psq8uKNQ15go1adJg_aem_QarzQIScYnFE_2Apmi8teQ#diff-4d7cfde89c6e8a7cd4389d705e63720727e42e474e8871c90b201b44e6c73545R67-R70)) to the styling, which revealed that we have a redundant bg color. This PR removes that.

## Screenshots

![image](https://github.com/user-attachments/assets/ef13951b-53f4-4a36-944c-8a97acab741b)

<img width="611" alt="image" src="https://github.com/user-attachments/assets/0c33efaf-2175-4a05-84d3-7e289c581ae8" />
