### PR TITLE
Remove cookies permission

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -11,14 +11,7 @@
     "128": "./icons/128.png"
   },
   "host_permissions": ["https://leetcode.com/problems/*"],
-  "permissions": [
-    "storage",
-    "webNavigation",
-    "cookies",
-    "scripting",
-    "tabs",
-    "activeTab"
-  ],
+  "permissions": ["storage", "webNavigation", "scripting", "tabs", "activeTab"],
   "content_scripts": [
     {
       "js": ["assets/index.js"],


### PR DESCRIPTION
# Description

Since we have authentication, reading cookies to infer username is no longer necessary.
