### PR TITLE
Deprecate chrome storage

### DIFF
--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -11,7 +11,7 @@
     "128": "./icons/128.png"
   },
   "host_permissions": ["https://leetcode.com/problems/*"],
-  "permissions": ["storage", "webNavigation", "scripting", "tabs", "activeTab"],
+  "permissions": ["webNavigation", "scripting", "tabs", "activeTab"],
   "content_scripts": [
     {
       "js": ["assets/index.js"],

--- a/extension/src/components/panel/AppPanel.tsx
+++ b/extension/src/components/panel/AppPanel.tsx
@@ -9,21 +9,25 @@ interface AppPanelProps {
 }
 
 export const AppPanel = (props: AppPanelProps) => {
-  const { appPreference, setAppWidth, onResizeStop, toggleWidth } =
-    useWindowDimensions();
+  const {
+    preference: { appPreference },
+    setAppWidth,
+    onResizeStop,
+    toggleWidth,
+  } = useWindowDimensions();
 
   return (
     <ResizableBox
       width={appPreference.isCollapsed ? MIN_WIDTH : appPreference.width}
       axis="x"
       resizeHandles={["w"]}
-      className="h-full flex relative"
+      className="relative flex h-full"
       handle={<div onDoubleClick={toggleWidth}>{VerticalHandle}</div>}
       minConstraints={[MIN_WIDTH, 0]}
       onResize={(_e, data) => setAppWidth(data.size.width)}
       onResizeStop={onResizeStop}
     >
-      <div className="w-full box-border ml-2 rounded-lg bg-layer-1 dark:bg-dark-layer-1 h-full">
+      <div className="bg-layer-1 dark:bg-dark-layer-1 ml-2 box-border h-full w-full rounded-lg">
         {appPreference.isCollapsed && <CollapsedPanel />}
         <div
           data-collapsed={appPreference.isCollapsed}

--- a/extension/src/components/panel/editor/EditorPanel.tsx
+++ b/extension/src/components/panel/editor/EditorPanel.tsx
@@ -21,8 +21,12 @@ const EditorPanel = () => {
   const { peers, activePeer, unblur, selectTest, isBuffer } =
     usePeerSelection();
   const { state: appState } = useAppState();
-  const { setCodePreferenceHeight, onResizeStop, codePreference, height } =
-    useWindowDimensions();
+  const {
+    setCodePreferenceHeight,
+    onResizeStop,
+    preference: { codePreference },
+    height,
+  } = useWindowDimensions();
 
   const canViewCode = activePeer?.viewable ?? false;
   const activeTest = activePeer?.tests.find((test) => test.selected);
@@ -34,14 +38,14 @@ const EditorPanel = () => {
         <LoadingPanel numberOfUsers={peers.length} />
       )}
       <div
-        className={cn("flex flex-col relative h-full w-full justify-between", {
+        className={cn("relative flex h-full w-full flex-col justify-between", {
           hidden: emptyRoom,
         })}
       >
         {/* todo(nickbar01234): Fix styling */}
         {!canViewCode && (
           <button
-            className="hover:bg-fill-quaternary dark:hover:bg-fill-quaternary text-label-1 dark:text-dark-label-1 font-bold py-2 px-4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg z-50"
+            className="hover:bg-fill-quaternary dark:hover:bg-fill-quaternary text-label-1 dark:text-dark-label-1 absolute left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lg px-4 py-2 font-bold"
             onClick={unblur}
             type="button"
           >
@@ -58,22 +62,22 @@ const EditorPanel = () => {
             height={codePreference.height}
             axis="y"
             resizeHandles={canViewCode ? ["s"] : undefined}
-            className="h-full flex relative w-full"
+            className="relative flex h-full w-full"
             minConstraints={[Infinity, height * 0.2]}
             maxConstraints={[Infinity, height * 0.5]}
             handle={
-              <div className="absolute bottom-0 h-2 bg-layer-bg-gray dark:bg-layer-bg-gray w-full">
-                <div className="relative top-1/2 -translate-y-1/2 flexlayout__splitter flexlayout__splitter_horz w-full h-[2px] hover:after:h-full hover:after:bg-[--color-splitter-drag] after:h-[2px] after:bg-[--color-splitter] cursor-ns-resize" />
+              <div className="bg-layer-bg-gray dark:bg-layer-bg-gray absolute bottom-0 h-2 w-full">
+                <div className="flexlayout__splitter flexlayout__splitter_horz relative top-1/2 h-[2px] w-full -translate-y-1/2 cursor-ns-resize after:h-[2px] after:bg-[--color-splitter] hover:after:h-full hover:after:bg-[--color-splitter-drag]" />
               </div>
             }
             onResize={(_e, data) => setCodePreferenceHeight(data.size.height)}
             onResizeStop={onResizeStop}
           >
-            <div className="relative h-full flex flex-col grow gap-y-2 w-full">
+            <div className="relative flex h-full w-full grow flex-col gap-y-2">
               <EditorToolBar />
               <div
                 id={EDITOR_NODE_ID}
-                className="w-full overflow-hidden h-full"
+                className="h-full w-full overflow-hidden"
               />
             </div>
           </ResizableBox>
@@ -83,15 +87,15 @@ const EditorPanel = () => {
           >
             <div className="mx-5 my-4 flex flex-col space-y-4">
               <div className="flex w-full flex-row items-start justify-between gap-4">
-                <div className="flex flex-nowrap items-center gap-x-2 gap-y-4 overflow-x-scroll hide-scrollbar">
+                <div className="hide-scrollbar flex flex-nowrap items-center gap-x-2 gap-y-4 overflow-x-scroll">
                   {activePeer?.tests.map((test, idx) => (
                     <div key={idx} onClick={() => selectTest(idx)}>
                       {test.selected ? (
-                        <button className="font-medium items-center whitespace-nowrap focus:outline-none inline-flex bg-fill-3 dark:bg-dark-fill-3 hover:bg-fill-2 dark:hover:bg-dark-fill-2 relative rounded-lg px-4 py-1 hover:text-label-1 dark:hover:text-dark-label-1 text-label-1 dark:text-dark-label-1">
+                        <button className="bg-fill-3 dark:bg-dark-fill-3 hover:bg-fill-2 dark:hover:bg-dark-fill-2 hover:text-label-1 dark:hover:text-dark-label-1 text-label-1 dark:text-dark-label-1 relative inline-flex items-center whitespace-nowrap rounded-lg px-4 py-1 font-medium focus:outline-none">
                           Case {idx + 1}
                         </button>
                       ) : (
-                        <button className="font-medium items-center whitespace-nowrap focus:outline-none inline-flex hover:bg-fill-2 dark:hover:bg-dark-fill-2 text-label-2 dark:text-dark-label-2 relative rounded-lg px-4 py-1 hover:text-label-1 dark:hover:text-dark-label-1 bg-transparent dark:bg-dark-transparent">
+                        <button className="hover:bg-fill-2 dark:hover:bg-dark-fill-2 text-label-2 dark:text-dark-label-2 hover:text-label-1 dark:hover:text-dark-label-1 dark:bg-dark-transparent relative inline-flex items-center whitespace-nowrap rounded-lg bg-transparent px-4 py-1 font-medium focus:outline-none">
                           Case {idx + 1}
                         </button>
                       )}
@@ -104,12 +108,12 @@ const EditorPanel = () => {
                   <div className="flex h-full w-full flex-col space-y-2">
                     {activeTest?.test.map((assignment, idx) => (
                       <React.Fragment key={idx}>
-                        <div className="text-xs font-medium text-label-3 dark:text-dark-label-3">
+                        <div className="text-label-3 dark:text-dark-label-3 text-xs font-medium">
                           {assignment.variable} =
                         </div>
-                        <div className="font-menlo w-full cursor-text rounded-lg border px-3 py-[10px] bg-fill-3 dark:bg-dark-fill-3 border-transparent">
+                        <div className="font-menlo bg-fill-3 dark:bg-dark-fill-3 w-full cursor-text rounded-lg border border-transparent px-3 py-[10px]">
                           <div
-                            className="font-menlo w-full resize-none whitespace-pre-wrap break-words outline-none placeholder:text-label-4 dark:placeholder:text-dark-label-4 sentry-unmask"
+                            className="font-menlo placeholder:text-label-4 dark:placeholder:text-dark-label-4 sentry-unmask w-full resize-none whitespace-pre-wrap break-words outline-none"
                             contentEditable="true"
                           >
                             {assignment.value}

--- a/extension/src/constants/index.ts
+++ b/extension/src/constants/index.ts
@@ -1,9 +1,9 @@
-import { ExtensionStorage } from "@cb/types";
+import { Preference } from "@cb/types";
 
 // todo(nickbar01234): Small hack since background.ts file can't recognize client-side env
 const env = (import.meta as any).env;
 
-export const CodeBuddyPreference: ExtensionStorage = {
+export const CodeBuddyPreference: Preference = {
   appPreference: {
     width: env.MODE === "development" ? 600 : 300 /* px */,
     isCollapsed: false,

--- a/extension/src/services/background.ts
+++ b/extension/src/services/background.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { CodeBuddyPreference } from "@cb/constants";
-import { setChromeStorage } from "@cb/services";
 import {
   ExtractMessage,
   ResponseStatus,
@@ -12,15 +10,6 @@ import {
 const servicePayload = <T extends ServiceRequest["action"]>(
   payload: ServiceResponse[T]
 ) => payload;
-
-/**
- * Initialize default settings
- */
-chrome.runtime.onInstalled.addListener((details) => {
-  if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
-    setChromeStorage({ ...CodeBuddyPreference });
-  }
-});
 
 const getValue = async () => {
   const monaco = (window as any).monaco;

--- a/extension/src/services/index.ts
+++ b/extension/src/services/index.ts
@@ -1,5 +1,5 @@
 import {
-  ExtensionStorage,
+  Preference,
   LocalStorage,
   ServiceRequest,
   ServiceResponse,
@@ -11,19 +11,12 @@ const LOCAL_STORAGE: Array<keyof LocalStorage> = [
   "tabs",
   "lastActivePeer",
   "signIn",
+  "preference",
 ];
 
 export const sendServiceRequest = <T extends ServiceRequest>(
   request: T
 ): Promise<ServiceResponse[T["action"]]> => chrome.runtime.sendMessage(request);
-
-export const setChromeStorage = (items: Partial<ExtensionStorage>) =>
-  chrome.storage.sync.set(items);
-
-export const getChromeStorage = <K extends keyof ExtensionStorage>(key: K) =>
-  chrome.storage.sync.get(key).then((pref) => pref[key]) as Promise<
-    ExtensionStorage[K]
-  >;
 
 export const getLocalStorage = <K extends keyof LocalStorage>(key: K) => {
   const maybeItem = localStorage.getItem(LOCAL_STORAGE_PREFIX + key);

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -34,7 +34,7 @@ export interface Peer {
   tests: TestCase[];
 }
 
-export interface ExtensionStorage {
+export interface Preference {
   appPreference: AppPreference;
   codePreference: CodePreference;
 }
@@ -53,4 +53,5 @@ export interface LocalStorage {
     url: string;
     tabId: number;
   };
+  preference: Preference;
 }


### PR DESCRIPTION
# Description

Rethinking about the minimal set of permissions required to make our extension work. I originally added chrome storage with the intention to sync preference across tabs. I don't think this is required for a v0 implementation, and we should be able to save user preference on local storage or firebase (for cross-browsers).

Note that the bulk of the diff comes from husky formatting.