### PR TITLE
Fix bug - Refresh for room creator

### DIFF
--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -388,7 +388,6 @@ export const RTCProvider = (props: RTCProviderProps) => {
       }
       // console.log("Joining room", roomId);
       setRoomId(roomId);
-      console.log("CHANGING ROOM ID FROM JOINING ")
       await setRoom(getRoomRef(roomId), {
         usernames: arrayUnion(username),
       });


### PR DESCRIPTION
# Description
* Bug: Previously
  * when a user create a new room, the roomId wasn't saved into localHost 
  * only the the new users coming in have roomId saved in localHost
  * thus, when refresh, the room creator will be out 
 
* Solution: Save roomId into localhost in createRoom() 
<!--  * Reasons why I didn't put it in PeerSelectionProvider as a useEffect func with roomId in the deps: -->
## Screenshots

<!-- For UI changes, include screenshots / recordings and describe the expected user flow -->

## Test

<!-- Describe how we can test your code -->

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [ ] Create room and join room on at least 2 browsers
- [ ] Ensure that code and tests are correctly stream
- [ ] Verify that when reloading, user can automatically join the room

## Possible Downsides

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
