### PR TITLE
Ignore installs and compiled code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {
+    ignores: ["**/node_modules/*", "**/dist/*"]
+  },
+  {
     rules: {
       "no-unused-vars": "off",
       "no-explicit-any": "off",
@@ -39,5 +42,5 @@ export default tseslint.config(
       ...react.configs.flat.recommended.languageOptions,
       globals: globals.browser,
     },
-  }
+  },
 );

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -8,7 +8,7 @@
     "dev": "pnpm i && tsc -w &",
     "test": "pnpm vitest"
   },
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "dependencies": {
     "@google-cloud/functions-framework": "^3.4.5",
     "firebase-admin": "^13.0.2",

--- a/firebase/functions/tsconfig.json
+++ b/firebase/functions/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "nodenext",
     "isolatedModules": true,
     "moduleDetection": "force",
-    "outDir": "lib",
+    "outDir": "dist",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
# Description

While husky is set to only run on changed code, inspecting Eslint manually shows 3000+ errors.

![image](https://github.com/user-attachments/assets/ce17378a-1254-44bc-97a7-a048302b84f7)

This PR ignores `node_modules/` and `dist/` from eslint check.

## Screenshots

![image](https://github.com/user-attachments/assets/7fe1c3a0-3516-4ab5-808c-5166818b6193)
