### PR TITLE
Fix and disable firebase/auth import

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,17 +1,17 @@
 // @ts-check
 
 import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
+import tsEslintPlugin from "@typescript-eslint/eslint-plugin";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
-import tsEslintPlugin from "@typescript-eslint/eslint-plugin";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {
-    ignores: ["**/node_modules/*", "**/dist/*"]
+    ignores: ["**/node_modules/*", "**/dist/*"],
   },
   {
     rules: {
@@ -37,10 +37,22 @@ export default tseslint.config(
     rules: {
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "firebase/auth",
+              message:
+                "firebase/auth is not supported for extension manifest v3. Please use firebase/auth/web-extension instead.",
+            },
+          ],
+        },
+      ],
     },
     languageOptions: {
       ...react.configs.flat.recommended.languageOptions,
       globals: globals.browser,
     },
-  },
+  }
 );

--- a/extension/src/db/setup.ts
+++ b/extension/src/db/setup.ts
@@ -1,8 +1,6 @@
-import { FirebaseOptions } from "firebase/app";
-import { initializeApp } from "firebase/app";
-import { getFirestore, connectFirestoreEmulator } from "firebase/firestore";
-import { getAuth } from "firebase/auth";
-import { connectAuthEmulator } from "firebase/auth/web-extension";
+import { FirebaseOptions, initializeApp } from "firebase/app";
+import { connectAuthEmulator, getAuth } from "firebase/auth/web-extension";
+import { connectFirestoreEmulator, getFirestore } from "firebase/firestore";
 
 const env = (import.meta as any).env;
 const DEV_VALUE = "demo-code-buddy-development";

--- a/extension/src/hooks/useAuthenticate.ts
+++ b/extension/src/hooks/useAuthenticate.ts
@@ -1,14 +1,14 @@
 import { auth } from "@cb/db";
-import { useOnMount } from ".";
 import { getLocalStorage } from "@cb/services";
 import { AuthenticationStatus, Status } from "@cb/types";
-import React from "react";
-import _ from "lodash";
-import { Unsubscribe } from "firebase/auth";
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  Unsubscribe,
 } from "firebase/auth/web-extension";
+import _ from "lodash";
+import React from "react";
+import { useOnMount } from ".";
 
 interface UseDevAuthenticateProps {
   authenticate: (session: AuthenticationStatus) => void;


### PR DESCRIPTION
# Description

Previously, we imported some functions from `firebase/auth`, which caused remote-hosted-scripts to be injected, namely:
* https://apis.google.com/js/api.js
* https://www.google.com/recaptcha/api.js
* https://www.google.com/recaptcha/enterprise.js?render=

This PR changed the import path and introduced an eslint rule to guard against this

## Screenshots

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/5674a829-582f-4f66-8ad2-236df31e1083" />

## Test

- Verified that the RHC scripts no longer show up in the build folder.
