### PR TITLE
Add padding to editor

### DIFF
--- a/extension/src/components/panel/editor/EditorPanel.tsx
+++ b/extension/src/components/panel/editor/EditorPanel.tsx
@@ -178,7 +178,7 @@ const EditorPanel = () => {
                   value={value}
                   forceMount
                   className={cn(
-                    "data-[state=inactive]:hidden hide-scrollbar overflow-auto h-full w-full"
+                    "data-[state=inactive]:hidden hide-scrollbar overflow-auto h-full w-full mt-0"
                   )}
                 >
                   {Content}

--- a/extension/src/components/panel/editor/tab/CodeTab.tsx
+++ b/extension/src/components/panel/editor/tab/CodeTab.tsx
@@ -16,7 +16,7 @@ export const CodeTab: React.FC = () => {
           hidden: isBuffer,
         })}
       >
-        <div className="absolute top-0 right-0 pr-6 z-50">
+        <div className="absolute top-2 right-0 pr-6 z-50">
           <button
             title="Paste code"
             type="button"

--- a/extension/src/services/background.ts
+++ b/extension/src/services/background.ts
@@ -69,6 +69,9 @@ const setupCodeBuddyModel = async (id: string) => {
           scrollBeyondLastLine: false,
           automaticLayout: true,
           minimap: { enabled: false },
+          padding: {
+            top: 8,
+          },
         }
       );
       buddyEditor.id = "CodeBuddy";


### PR DESCRIPTION
# Description

Add padding to monaco editor

## Screenshots

Before (notice the weird bg-color)

![image](https://github.com/user-attachments/assets/4efcf2d6-933a-4ad9-bfd6-83ff0cb0f39f)

After

![image](https://github.com/user-attachments/assets/71ea2348-31bf-4acd-85fa-79110ceb0f42)


## Test

<!-- Describe how we can test your code -->

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [ ] Create room and join room on at least 2 browsers
- [ ] Ensure that code and tests are correctly stream
- [ ] Verify that when reloading, user can automatically join the room

## Possible Downsides

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
