### PR TITLE
Reorder firebase to match security

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -15,12 +15,15 @@ service cloud.firestore {
 
     // Allow only authenticated access to database
     match /rooms/{roomId} {
+      function isPermittedToModify() {
+        return request.auth != null && request.auth.token.email in get(/databases/$(database)/documents/rooms/$(roomId)).data.usernames;
+      }
+
       allow read, create: if request.auth != null;
-      allow update: if request.auth != null 
-      && request.resource.data.diff(resource.data).changedKeys().hasOnly(['usernames']);
+      allow update: if request.auth != null && request.resource.data.diff(resource.data).changedKeys().hasOnly(['usernames']);
+
       match /sessions/{document=**} {
-         allow read, write: if request.auth != null
-          && request.auth.token.email in get(/databases/$(database)/documents/rooms/$(roomId)).data.usernames;
+         allow read, write: if isPermittedToModify()
       }
     }
   }


### PR DESCRIPTION
# Description

Since #186, we only allow user with names inside `rooms/${roomId}` to modify the room. Fixing `RTCProvider` to match that expectation -- note we would have catched this with integration tests, unfortunately.

