### PR TITLE
Reload extension on build end

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm run \"/^build:.*/\"",
     "dev:build": "pnpm run build --mode development",
     "dev:prod": "pnpm run build && concurrently --kill-others \"pnpm run build --watch\"",
-    "dev": "pnpm run dev:build && concurrently --kill-others \"node script/dev.mjs\" \"pnpm run dev:build --watch\"",
+    "dev": "concurrently --kill-others \"node script/dev.mjs\" \"pnpm run dev:build --watch\"",
     "dev:1": "USERS=1 pnpm run dev",
     "dev:3": "USERS=3 pnpm run dev",
     "dev:4": "USERS=4 pnpm run dev",

--- a/extension/script/dev.mjs
+++ b/extension/script/dev.mjs
@@ -1,6 +1,5 @@
 /* eslint-disable */
 
-import chokidar from "chokidar";
 import _ from "lodash";
 import puppeteer from "puppeteer";
 
@@ -22,6 +21,11 @@ const PEERS = Array.from({ length: NUM_USERS }).map((_, idx) => ({
   peer: USERNAMES[idx],
 }));
 const ROOM_ID = `CODE_BUDDY_TEST_${Date.now()}`;
+
+// Keep in sync with package.json / vite.config.ts
+const DEV_SCRIPT_HINT = ["content_script", "service_worker"].map(
+  (file) => `${EXTENSION_PATH}/${file}`
+);
 
 const setup = async () => {
   const createBrowser = async (peer) => {
@@ -87,8 +91,8 @@ const reload = _.debounce(() => {
 setup()
   .then(() => {
     chokidar
-      .watch(EXTENSION_PATH, { awaitWriteFinish: true })
-      .on("change", reload);
+      .watch(DEV_SCRIPT_HINT, { awaitWriteFinish: true })
+      .on("add", reload);
   })
   .catch((e) => console.error("Failed with", e));
 

--- a/extension/src/components/navigator/menu/RoomControlMenu.tsx
+++ b/extension/src/components/navigator/menu/RoomControlMenu.tsx
@@ -14,9 +14,10 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@cb/lib/components/ui/dropdown-menu";
-import { clearLocalStorage } from "@cb/services";
+import { clearLocalStorage, sendServiceRequest } from "@cb/services";
 import { signOut } from "firebase/auth/web-extension";
 import { throttle } from "lodash";
+import { Hammer } from "lucide-react";
 import React from "react";
 import { RoomControlDropdownMenuItem } from "./RoomControlDropdownMenuItem";
 
@@ -101,6 +102,16 @@ export const RoomControlMenu = () => {
             <ResetIcon /> <span>Reset Extension</span>
           </span>
         </RoomControlDropdownMenuItem>
+        {import.meta.env.MODE === "development" && (
+          <RoomControlDropdownMenuItem
+            onSelect={() => sendServiceRequest({ action: "reloadExtension" })}
+          >
+            <span className="flex items-center gap-2">
+              <Hammer />
+              <span>Reload extension</span>
+            </span>
+          </RoomControlDropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
# Description

As our extension becomes bigger, the build process becomes slower. The previous implementation for `dev.mjs` reload the extension every time `dist/` changes, but that does not mean that the code has finished compiling.

Now, we add a hook post-build to write a marker to `dist/`, which signals `dev.mjs` that the build has completed, and it's safe to reload. As a break-glass solution, I also expose a reload option via the drop down. Note that this requires a browser refresh.

![image](https://github.com/user-attachments/assets/87f1738f-fd4c-4db4-91f3-3d20a35aeb70)

