### PR TITLE
Reduce width

### DIFF
--- a/extension/src/components/dialog/SelectProblemDialog.tsx
+++ b/extension/src/components/dialog/SelectProblemDialog.tsx
@@ -32,7 +32,7 @@ export const SelectProblemDialog = ({
       content={{
         props: {
           className:
-            "h-[90vh] min-w-[80%] max-w-[80%] py-6 px-3 bg-layer-1 bg-white dark:bg-dark-layer-bg flex flex-col gap-4",
+            "h-[90vh] max-w-[1100px] py-6 px-3 bg-layer-1 bg-white dark:bg-dark-layer-bg flex flex-col gap-4",
         },
       }}
       title={{ node: "Select next problem" }}


### PR DESCRIPTION
# Description

Leetcode imposes a maximum height. Instead of trying to figure out how to override this, let's just keep the dialog width minimum.
