### PR TITLE
Add background in wrapper div

### DIFF
--- a/extension/src/components/dialog/RoomDialog.tsx
+++ b/extension/src/components/dialog/RoomDialog.tsx
@@ -13,7 +13,7 @@ import React, { ReactNode } from "react";
 
 //note that the classname from leetcode is not applying because dialog is not in leetcode environment. We could still use classname from our tailwind tho.
 export const baseButtonClassName =
-  "rounded-md text-black dark:text-white py-2 font-medium text-base transition hover:bg-[--color-button-hover-background] bg-[--color-button-background] border-transparent hover:border-black dark:hover:border-white border";
+  "rounded-md text-[#1E1E1E] dark:text-white py-2 font-medium text-base transition hover:bg-[--color-button-hover-background] bg-[--color-button-background] border-transparent hover:border-black dark:hover:border-white border";
 
 export interface RoomDialogProps {
   dialog?: {
@@ -55,16 +55,21 @@ export const RoomDialog: React.FC<RoomDialogProps> = ({
           {trigger.customTrigger ? (
             trigger.node
           ) : (
-            <Button
-              {...d(trigger?.props, {})}
-              className={cn(
-                "flex items-center justify-center dark:text-white text-black w-[150px] hover:bg-[--color-button-hover-background] bg-[--color-button-background] dark:hover:bg-[--color-button-hover-background] dark:bg-[--color-button-background]",
-                trigger?.props?.className
-              )}
-              aria-label={trigger.label}
-            >
-              {trigger.node}
-            </Button>
+            // todo(nickbar01234): For some reason, background doesn't override in light mode?
+            <div className="bg-[--color-button-background]">
+              <Button
+                {...d(trigger?.props, {})}
+                className={cn(
+                  // "flex items-center justify-center dark:text-white text-[#1E1E1E] w-[150px] hover:bg-[--color-button-hover-background] bg-[--color-button-background] dark:hover:bg-[--color-button-hover-background] dark:bg-[--color-button-background]",
+                  "flex items-center justify-center w-[150px]",
+                  baseButtonClassName,
+                  trigger?.props?.className
+                )}
+                aria-label={trigger.label}
+              >
+                {trigger.node}
+              </Button>
+            </div>
           )}
         </DialogTrigger>
       )}


### PR DESCRIPTION
# Description

For some reason, background color for button doesn't showup in light mode ... bug on shadcn/ui?

## Screenshots

Before
![image](https://github.com/user-attachments/assets/b16ec57e-5729-4966-92e4-50e3a1b8fad2)

After
![image](https://github.com/user-attachments/assets/7775dab9-784f-4ec2-a517-60410192a9a3)

## Possible Downsides

tbh, not a big fan of this background color yet, since it feels quite light in light theme, but no reason to block