### PR TITLE
Recompute current url

### DIFF
--- a/extension/src/components/dialog/PromptNavigateDialog.tsx
+++ b/extension/src/components/dialog/PromptNavigateDialog.tsx
@@ -2,8 +2,7 @@ import { useRTC } from "@cb/hooks";
 import { Button } from "@cb/lib/components/ui/button";
 import { DialogClose } from "@cb/lib/components/ui/dialog";
 import { getLocalStorage, setLocalStorage } from "@cb/services";
-import { getQuestionIdFromUrl } from "@cb/utils";
-import React from "react";
+import { getSessionId } from "@cb/utils";
 import { baseButtonClassName, RoomDialog } from "./RoomDialog";
 
 interface PromptNavigateDialogProps {
@@ -15,16 +14,12 @@ export const PromptNavigateDialog = ({
 }: PromptNavigateDialogProps) => {
   const { handleNavigateToNextQuestion } = useRTC();
   const navigatePrompt = getLocalStorage("navigatePrompt") ?? {};
-  const sessionId = React.useMemo(
-    () => getQuestionIdFromUrl(window.location.href),
-    []
-  );
-  const displayPrompt = finished && !(navigatePrompt[sessionId] ?? false);
+  const displayPrompt = finished && !(navigatePrompt[getSessionId()] ?? false);
 
   const onDecision = () =>
     setLocalStorage("navigatePrompt", {
       ...navigatePrompt,
-      [sessionId]: true,
+      [getSessionId()]: true,
     });
 
   const onNavigate = () => {

--- a/extension/src/components/navigator/AppNavigator.tsx
+++ b/extension/src/components/navigator/AppNavigator.tsx
@@ -5,7 +5,7 @@ import { LoadingPanel } from "@cb/components/panel/LoadingPanel";
 import { AppState, appStateContext } from "@cb/context/AppStateProvider";
 import useDevSetupRoom from "@cb/hooks/useDevSetupRoom";
 import { getLocalStorage } from "@cb/services";
-import { getQuestionIdFromUrl } from "@cb/utils";
+import { getSessionId } from "@cb/utils";
 import React from "react";
 
 export const AppNavigator = () => {
@@ -20,11 +20,8 @@ export const AppNavigator = () => {
         {state === AppState.LOADING ? (
           <LoadingPanel
             numberOfUsers={
-              Object.keys(
-                currentTabInfo?.sessions[
-                  getQuestionIdFromUrl(window.location.href)
-                ]?.peers ?? {}
-              ).length
+              Object.keys(currentTabInfo?.sessions[getSessionId()]?.peers ?? {})
+                .length
             }
           />
         ) : state === AppState.REJOINING ? (

--- a/extension/src/components/panel/editor/tab/roomInfo/RoomInfoTab.tsx
+++ b/extension/src/components/panel/editor/tab/roomInfo/RoomInfoTab.tsx
@@ -10,7 +10,7 @@ import {
   useRTC,
 } from "@cb/hooks/index";
 import { Button } from "@cb/lib/components/ui/button";
-import { getQuestionIdFromUrl } from "@cb/utils";
+import { getSessionId } from "@cb/utils";
 import { cn } from "@cb/utils/cn";
 import { formatTime } from "@cb/utils/heartbeat";
 import { Timestamp } from "firebase/firestore";
@@ -22,10 +22,6 @@ export const RoomInfoTab = () => {
     user: { username },
   } = useAppState();
   const { roomId, peerState, handleNavigateToNextQuestion } = useRTC();
-  const sessionId = React.useMemo(
-    () => getQuestionIdFromUrl(window.location.href),
-    []
-  );
   const [chooseNextQuestion, setChooseNextQuestion] = React.useState(false);
   const [showNavigatePrompt, setShowNavigatePrompt] = React.useState(false);
   const [choosePopUp, setChoosePopup] = React.useState(false);
@@ -35,7 +31,8 @@ export const RoomInfoTab = () => {
     init: { usernames: [], isPublic: true, roomName: "" },
   });
   const { data: sessionDoc } = useFirebaseListener({
-    reference: roomId != null ? getSessionRef(roomId, sessionId) : undefined,
+    reference:
+      roomId != null ? getSessionRef(roomId, getSessionId()) : undefined,
     callback: async (sessionData) => {
       const data = sessionData;
       // todo(nickbar01234): Clear and report room if deleted?
@@ -111,7 +108,7 @@ export const RoomInfoTab = () => {
           <h2 className="text-xl font-bold mb-3">
             {sessionDoc?.nextQuestion != ""
               ? sessionDoc?.nextQuestion
-              : getQuestionIdFromUrl(window.location.href)}
+              : getSessionId()}
             <span className="text-orange-400 ml-2">[Medium]</span>
           </h2>
           <div className="flex gap-2 mb-4">

--- a/extension/src/context/PeerSelectionProvider.tsx
+++ b/extension/src/context/PeerSelectionProvider.tsx
@@ -7,7 +7,7 @@ import {
   setLocalStorage,
 } from "@cb/services";
 import { Peer, PeerInformation, ResponseStatus, TestCase } from "@cb/types";
-import { getQuestionIdFromUrl } from "@cb/utils";
+import { getSessionId } from "@cb/utils";
 import { poll } from "@cb/utils/poll";
 import React from "react";
 
@@ -42,9 +42,6 @@ export const PeerSelectionProvider: React.FC<PeerSelectionProviderProps> = ({
   const [changeUser, setChangeUser] = React.useState<boolean>(false);
   const [isBuffer, setIsBuffer] = React.useState<boolean>(true);
   const { variables } = useInferTests();
-  const sessionId = React.useMemo(() => {
-    return getQuestionIdFromUrl(window.location.href);
-  }, []);
 
   const activeUserInformation = React.useMemo(
     () => (activePeer == undefined ? undefined : informations[activePeer?.id]),
@@ -175,10 +172,11 @@ export const PeerSelectionProvider: React.FC<PeerSelectionProviderProps> = ({
 
   const getLocalStorageForIndividualPeers = React.useCallback(
     (peerId: string) => {
-      const sessions = getLocalStorage("tabs")?.sessions[sessionId]?.[peerId];
+      const sessions =
+        getLocalStorage("tabs")?.sessions[getSessionId()]?.[peerId];
       return sessions ?? undefined;
     },
-    [sessionId]
+    []
   );
 
   const setLocalStorageForIndividualPeers = React.useCallback(
@@ -190,17 +188,17 @@ export const PeerSelectionProvider: React.FC<PeerSelectionProviderProps> = ({
         roomId: roomId,
         sessions: {},
       };
-      const currentRoom = currentInfo.sessions[sessionId ?? ""];
+      const currentRoom = currentInfo.sessions[getSessionId()];
       if (!currentRoom) {
-        currentInfo.sessions[sessionId ?? ""] = {};
+        currentInfo.sessions[getSessionId()] = {};
       }
-      const currentPeers = currentInfo.sessions[sessionId];
+      const currentPeers = currentInfo.sessions[getSessionId()];
       currentPeers[peer.id] = {
         ...peer,
       };
       setLocalStorage("tabs", currentInfo);
     },
-    [roomId, sessionId]
+    [roomId]
   );
 
   React.useEffect(() => {

--- a/extension/src/hooks/auth/useSignInWithEmailLink.tsx
+++ b/extension/src/hooks/auth/useSignInWithEmailLink.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@cb/db";
 import { sendServiceRequest, setLocalStorage } from "@cb/services";
-import { constructUrlFromQuestionId, getQuestionIdFromUrl } from "@cb/utils";
+import { constructUrlFromQuestionId, getSessionId } from "@cb/utils";
 import { FirebaseError } from "firebase/app";
 import {
   ActionCodeSettings,
@@ -34,9 +34,7 @@ export const useSignInWithEmailLink = () => {
 
   const actionCodeSettings: ActionCodeSettings = React.useMemo(
     () => ({
-      url: constructUrlFromQuestionId(
-        getQuestionIdFromUrl(window.location.href)
-      ),
+      url: constructUrlFromQuestionId(getSessionId()),
       handleCodeInApp: true,
     }),
     []

--- a/extension/src/utils/url.ts
+++ b/extension/src/utils/url.ts
@@ -9,6 +9,8 @@ export const getQuestionIdFromUrl = (url: string) => {
   throw new Error("Invalid Leetcode URL");
 };
 
+export const getSessionId = () => getQuestionIdFromUrl(window.location.href);
+
 export const constructUrlFromQuestionId = (questionId: string) => {
   return `https://leetcode.com/problems/${questionId}`;
 };


### PR DESCRIPTION
# Description

Resolve #310.

Leetcode replaces the url state without actually refreshing if you select a problem via the side panel. Previous implementation memoized `sessionId`. Therefore, we actually can't  pick up the new url without refreshing the entire page