### PR TITLE
Check for room existence before setting room id

### DIFF
--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -427,12 +427,14 @@ export const RTCProvider = (props: RTCProviderProps) => {
       await setRoom(getRoomRef(roomId), {
         usernames: arrayUnion(username),
       });
-      setRoomId(roomId);
+      // todo(nickbar01234): Ask user to redirect
       const sessionDoc = await getSession(roomId, getSessionId());
       if (!sessionDoc.exists()) {
         toast.error("Session does not exist");
         return false;
       }
+
+      setRoomId(roomId);
       await setSession(getSessionRef(roomId, getSessionId()), {
         usernames: arrayUnion(username),
       });
@@ -775,7 +777,9 @@ export const RTCProvider = (props: RTCProviderProps) => {
         }
       );
       registerSnapshot(roomId, unsubscribe, (prev) => prev());
-      return () => evictSnapshot(roomId);
+      return () => {
+        evictSnapshot(roomId);
+      };
     }
   }, [
     roomId,


### PR DESCRIPTION
# Description

If we first set room and then realize the session does not exist, users have no way of recovering. This is a temporary fix until we have some bandwidth to refactor.
