### PR TITLE
Memoize hooks value

### DIFF
--- a/extension/src/components/panel/editor/EditorPanel.tsx
+++ b/extension/src/components/panel/editor/EditorPanel.tsx
@@ -47,8 +47,12 @@ const EditorPanel = () => {
   } = useWindowDimensions();
   const { roomId } = useRTC();
   const { getLanguageExtension } = useLanguageExtension();
+  const roomReference = React.useMemo(
+    () => (roomId != null ? getRoomRef(roomId) : undefined),
+    [roomId]
+  );
   const { data: roomInfo } = useFirebaseListener({
-    reference: roomId != null ? getRoomRef(roomId) : undefined,
+    reference: roomReference,
     // todo(nickbar01234): Port to redux
     init: { usernames: [], isPublic: true, roomName: "" },
   });

--- a/extension/src/hooks/useFirebaseListener.spec.ts
+++ b/extension/src/hooks/useFirebaseListener.spec.ts
@@ -6,10 +6,7 @@ import {
   Unsubscribe,
 } from "firebase/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useFirebaseListener,
-  UseFirebaseListenerProps,
-} from "./useFirebaseListener";
+import { useFirebaseListener } from "./useFirebaseListener";
 
 const mocks = vi.hoisted(() => ({
   onSnapshot: vi.fn(),
@@ -22,16 +19,14 @@ vi.mock("firebase/firestore", () => ({
 describe("useFirebaseListener", () => {
   const REFERENCE = { id: "id" } as DocumentReference;
   const INITIALIZED = { users: [] };
-  let callback: UseFirebaseListenerProps<unknown>["callback"];
 
   beforeEach(() => {
     vi.resetAllMocks();
-    callback = vi.fn();
   });
 
   it("data is initialized", () => {
     const { result } = renderHook(() =>
-      useFirebaseListener({ reference: REFERENCE, callback, init: INITIALIZED })
+      useFirebaseListener({ reference: REFERENCE, init: INITIALIZED })
     );
     expect(result.current.data).toBe(INITIALIZED);
   });
@@ -48,13 +43,12 @@ describe("useFirebaseListener", () => {
       }
     );
     const { result } = renderHook(() =>
-      useFirebaseListener({ reference: REFERENCE, callback, init: INITIALIZED })
+      useFirebaseListener({ reference: REFERENCE, init: INITIALIZED })
     );
     expect(result.current.data).toBe(INITIALIZED);
-    expect(callback).toHaveBeenCalledTimes(0);
   });
 
-  it("data exists returns and execute callback", () => {
+  it("data exists returns", () => {
     const data = { key: "value" };
     // Mocking overloaded signature is alot of sadness
     mocks.onSnapshot.mockImplementationOnce(
@@ -72,10 +66,9 @@ describe("useFirebaseListener", () => {
       }
     );
     const { result } = renderHook(() =>
-      useFirebaseListener({ reference: REFERENCE, callback, init: INITIALIZED })
+      useFirebaseListener({ reference: REFERENCE, init: INITIALIZED })
     );
     expect(result.current.data).toBe(data);
-    expect(callback).toHaveBeenCalledExactlyOnceWith(data);
   });
 
   it("undefined reference is no-op", () => {


### PR DESCRIPTION
# Description

Another iteration to #323. Previously, since the arg to the hook is not memoized, we end up re-triggering the useEffect all the time, which also contributed to the massive read spikes

## Screenshots

Before

![image](https://github.com/user-attachments/assets/81f4bf55-1261-4078-b56a-b085ff0fa4bd)

After

![image](https://github.com/user-attachments/assets/6f6f3fb7-43aa-483a-a613-78de6d3c436d)