### PR TITLE
Clear local storage for room

### DIFF
--- a/extension/src/components/dialog/RejoinPromptDialog.tsx
+++ b/extension/src/components/dialog/RejoinPromptDialog.tsx
@@ -16,9 +16,7 @@ export const RejoinPromptDialog = () => {
       removeLocalStorage("closingTabs");
       event.stopPropagation?.();
       setAppState(AppState.HOME);
-      if (roomId) {
-        leaveRoom(roomId);
-      }
+      leaveRoom(roomId);
     }, 1000);
   }, [roomId, leaveRoom, setAppState]);
 

--- a/extension/src/context/RTCProvider.tsx
+++ b/extension/src/context/RTCProvider.tsx
@@ -18,7 +18,7 @@ import {
 import { useAppState, useOnMount } from "@cb/hooks";
 import useResource from "@cb/hooks/useResource";
 import {
-  clearLocalStorage,
+  clearLocalStorageForRoom,
   getLocalStorage,
   sendServiceRequest,
   setLocalStorage,
@@ -556,12 +556,13 @@ export const RTCProvider = (props: RTCProviderProps) => {
 
   const leaveRoom = React.useCallback(
     async (roomId: string | null, reload = false) => {
-      if (roomId == null) return;
-      console.log("Leaving room", roomId);
       if (!reload) {
         console.log("Cleaning up local storage");
-        clearLocalStorage();
+        clearLocalStorageForRoom();
       }
+
+      if (roomId == null) return;
+      console.log("Leaving room", roomId);
 
       try {
         const roomDoc = (await getRoom(roomId)).data();

--- a/extension/src/services/index.ts
+++ b/extension/src/services/index.ts
@@ -34,5 +34,10 @@ export const setLocalStorage = <K extends keyof LocalStorage>(
   localStorage.setItem(LOCAL_STORAGE_PREFIX + key, JSON.stringify(value));
 };
 
-export const clearLocalStorage = () =>
-  LOCAL_STORAGE.forEach(removeLocalStorage);
+export const clearLocalStorage = (ignore: Array<keyof LocalStorage> = []) =>
+  LOCAL_STORAGE.filter((key) => !ignore.includes(key)).forEach(
+    removeLocalStorage
+  );
+
+export const clearLocalStorageForRoom = () =>
+  clearLocalStorage(["preference", "signIn"]);


### PR DESCRIPTION
# Description

Prior, clicking no on rejoint-prompt doesn't actually clear any information from local storage, so the dialog would show up every time. Additionally, leaving room would clear all the local storage information, including window preference, which does not seem like what we would want.
