### PR TITLE
Add redux-devtools to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
   apt-get install -y openjdk-${JAVA_VERSION}-jre bash && \
   npm install -g pnpm@${PNPM_VERSION} && \
   npm cache clean --force && \
+  npm install -g @redux-devtools/cli \
   pnpm install -g firebase-tools@${FIREBASE_VERSION} typescript && \
   firebase -V && \
   java --version

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,11 @@ services:
       - 3001:3001
       - 3002:3002
       - 3003:3003
+      # See entrypoint - used for remote-devtools
+      - 8000:8000
+      - 8001:8001
+      - 8002:8002
+      - 8003:8003
     environment:
       # Used by entrypoint
       - DATA_DIR=/app/mnt/data
@@ -26,6 +31,6 @@ services:
       resources:
         limits:
           memory: 1G
-          cpus: '1'
+          cpus: "1"
 volumes:
   db:

--- a/entrypoint
+++ b/entrypoint
@@ -3,6 +3,11 @@
 # Not setting this because firebase complains since we're not authenticated
 # set -e -o pipefail
 
+redux-devtools --hostname=localhost --port=8000 --name='Code' &
+redux-devtools --hostname=localhost --port=8001 --name='Buddy' &
+redux-devtools --hostname=localhost --port=8002 --name='Dev' &
+redux-devtools --hostname=localhost --port=8003 --name='Mode' &
+
 FUNCTIONS_DIR="$FIREBASE_DIR/functions"
 CONFIG_PATH="$FIREBASE_DIR/firebase.json"
 # https://firebase.google.com/docs/emulator-suite/connect_firestore#choose_a_firebase_project

--- a/extension/dev.sh
+++ b/extension/dev.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-redux-devtools --hostname=localhost --port=8000 --open --name='Code' &
-redux-devtools --hostname=localhost --port=8001 --open --name='Buddy' &
-# redux-devtools --hostname=localhost --port=8002 --open --name='Dev' &
-# redux-devtools --hostname=localhost --port=8003 --open --name='Mode' &
-
-pnpm run dev


### PR DESCRIPTION
# Description

Remove the need to install `redux-devtool/cli` globally, while we iterate with the maintainer on this [issue](https://github.com/reduxjs/redux-devtools/issues/1873).
