### PR TITLE
Skip off if handler is undefined

### DIFF
--- a/extension/src/services/controllers/WebRtcController.ts
+++ b/extension/src/services/controllers/WebRtcController.ts
@@ -108,23 +108,26 @@ export class WebRtcController {
       }
     };
 
-    const handleIceEvents = this.handleIceEvents.bind(this);
-    const handleDescriptionEvents = this.handleDescriptionEvents.bind(this);
-
-    this.emitter.on("rtc.ice", handleIceEvents);
-    this.emitter.on("rtc.description", handleDescriptionEvents);
+    const unsubscribeFromIceEvents = this.emitter.on(
+      "rtc.ice",
+      this.handleIceEvents.bind(this)
+    );
+    const unsubscribeFromDescriptionEvents = this.emitter.on(
+      "rtc.description",
+      this.handleDescriptionEvents.bind(this)
+    );
 
     channel.onopen = () => {
       console.log("Channel open", user);
-      this.emitter.off("rtc.ice", handleIceEvents);
-      this.emitter.off("rtc.description", handleDescriptionEvents);
+      unsubscribeFromIceEvents();
+      unsubscribeFromDescriptionEvents();
       this.emitter.emit("rtc.open", { user });
     };
 
     channel.onclose = () => {
       console.log("Channel closed", user);
-      this.emitter.off("rtc.ice", handleIceEvents);
-      this.emitter.off("rtc.description", handleDescriptionEvents);
+      unsubscribeFromIceEvents();
+      unsubscribeFromDescriptionEvents();
     };
 
     channel.onmessage = (event: MessageEvent) => {

--- a/extension/src/services/events/index.ts
+++ b/extension/src/services/events/index.ts
@@ -48,7 +48,8 @@ const createEmitter = <
     off<Key extends keyof Events>(type: Key, handler: Handler<Events[Key]>) {
       const filterable = handlers.get(type)?.get(handler);
       handlers.get(type)?.delete(handler);
-      emitter.off(type, filterable);
+      // mitt removes all handlers for type if filterable is undefined
+      if (filterable != undefined) emitter.off(type, filterable);
     },
 
     emit: emitter.emit,


### PR DESCRIPTION
# Description

Unfortunately, `mitt` will remove all handlers for a given type if input handler is undefined. Meaning if you leave room, a re-join won't be able to re-negotiate, since the other side would have removed `rtc.ice` and `rtc.description`, necessary for database calls.