### PR TITLE
Disallow room join at max capacity

### DIFF
--- a/extension/src/services/controllers/RoomController.ts
+++ b/extension/src/services/controllers/RoomController.ts
@@ -157,6 +157,10 @@ class RoomLifeCycle {
   }
 }
 
+type RoomJoinResponse =
+  | { code: RoomJoinCode.SUCCESS; data: RoomLifeCycle }
+  | { code: Exclude<RoomJoinCode, RoomJoinCode.SUCCESS> };
+
 export class RoomController {
   private database: DatabaseService["room"];
 
@@ -186,7 +190,7 @@ export class RoomController {
     return this.room;
   }
 
-  public async join(id: Id) {
+  public async join(id: Id): Promise<RoomJoinResponse> {
     if (this.room != null) {
       return { code: RoomJoinCode.SUCCESS, data: this.room };
     }

--- a/extension/src/store/roomStore.ts
+++ b/extension/src/store/roomStore.ts
@@ -81,7 +81,7 @@ const createRoomStore = (
                 get().actions.room.loading();
                 const response = await getOrCreateControllers().room.join(id);
                 if (response.code === RoomJoinCode.SUCCESS) {
-                  const { name, isPublic } = response.data!.getRoom();
+                  const { name, isPublic } = response.data.getRoom();
                   setRoom({ id, name, isPublic });
                 } else {
                   if (response.code === RoomJoinCode.NOT_EXISTS) {


### PR DESCRIPTION
# Description

<!-- Describe the context / changes in this PR -->
Throw an error to prevent the user from joining a room at max capacity. However, if the user reloads the page for whatever reason, they can still rejoin the same room.

## Screenshots

<!-- For UI changes, include screenshots / recordings and describe the expected user flow -->
<img width="914" height="995" alt="image" src="https://github.com/user-attachments/assets/966fb080-7598-4fb3-a269-46f86dcf5bd1" />


## Test

<!-- Describe how we can test your code -->
Open 5 browsers and try to join the same room.

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [ ] Create room and join room on at least 2 browsers
- [ ] Ensure that code and tests are correctly stream
- [ ] Verify that when reloading, user can automatically join the room

## Possible Downsides

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
