### PR TITLE
fix questions table's ui

### DIFF
--- a/extension/src/components/panel/problem/index.tsx
+++ b/extension/src/components/panel/problem/index.tsx
@@ -33,25 +33,9 @@ export const QuestionSelectorPanel = React.memo(
 
     useEffect(() => {
       const handleIframeStyle = async (iframeDoc: Document) => {
-        const sidebarObserver = new MutationObserver((_, obs) => {
-          const btn = iframeDoc
-            .querySelector(
-              'button[data-state="closed"] svg[data-icon="sidebar"]'
-            )
-            ?.closest("button");
-
-          if (btn) {
-            btn.remove();
-            console.log("Sidebar toggle button removed");
-
-            obs.disconnect();
-          }
-        });
-
-        sidebarObserver.observe(iframeDoc.body, {
-          childList: true,
-          subtree: true,
-        });
+        waitForElement('button svg[data-icon="sidebar"]', iframeDoc)
+          .then((el) => el.closest("button")?.remove())
+          .catch(() => {});
 
         const rowContainer = (await waitForElement("a#\\31 ", iframeDoc))
           .parentNode as Element;


### PR DESCRIPTION
# Description
#### Goal: remove 'unfold' button on the corner left
<img width="808" height="685" alt="Screenshot 2025-08-30 at 17 33 35" src="https://github.com/user-attachments/assets/d21041c3-2abe-42d7-b568-f1fd9638dff0" />

#### What I did:
1. Locate which part in UI: ` 'button[data-state="closed"]'`,  ` 'svg[data-icon="sidebar"]'`
+ This isn't part of our React component, it's injected inside iframe (LeetCode's DOM)  
+ Solution: run DOM manipulation inside iframe

2. Create `removeSidebarToggles` and call it -> observe that it not disappear completely 
+ Reason: Every time our React re-renders, the button gets injected back into the DOM.
So if I only remove() it once, it reappears later
+ Solution: Use `MutationObserver`: If the sidebar button gets re-inserted, we catch it and btn.remove() again instantly

#### Documentations
1. https://developer.chrome.com/blog/detect-dom-changes-with-mutation-observers?utm_source=chatgpt.com : shows how to observe when elements appear/disappear and act on them 
2. https://javascript.info/mutation-observer?utm_source=chatgpt.com: example use case 

## Screenshots
https://github.com/user-attachments/assets/760590c4-1f82-40e1-856a-c5bee82609d8
Button removed 

## Test
1. Pull branch 
3. Run
4. Create room, click on "Select next problem" and observe

## Checklist
If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [x] Create room and join room on at least 2 browsers
- [x] Ensure that code and tests are correctly stream
- [x] Verify that when reloading, user can automatically join the room

## Possible Downsides
1. If LeetCode changes their markup (`data-state="closed"` to something else, or changes the icon name), this removal will silently stop working
3. Because React might insert the button before our observer runs, users could see the button flash for a split second before it’s removed →  this hasn't happened until now
4. Removing elements might break some intended keyboard navigation → this hasn't happened until now

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
