### PR TITLE
Add padding bottom to monaco editor

### DIFF
--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -70,6 +70,12 @@ export default defineBackground(() => {
           top: 8,
         },
       });
+      editor.updateOptions({
+        padding: {
+          bottom:
+            editor.getOption(window.monaco.editor.EditorOption.lineHeight) * 8,
+        },
+      });
       (editor as any).id = "CodeBuddy";
       return {
         status: 0,


### PR DESCRIPTION
# Description

Prior, code is cut off. 

<img width="1842" height="1502" alt="image" src="https://github.com/user-attachments/assets/cc1f121c-f247-41ba-9b11-4d6398d400b1" />

We now add some extra padding at the end. I considered using `scrollBeyondLastLine: true`, but that would result in too much vertical space. Instead, I've decided to add 8 "blank lines" via padding.

## Screenshots

<img width="321" height="903" alt="image" src="https://github.com/user-attachments/assets/3fad1672-b203-4c61-8972-ca7f8a005523" />