### PR TITLE
Fix menu dropdown lingers after leave room

### DIFF
--- a/extension/src/components/navigator/menu/RoomControlMenu.tsx
+++ b/extension/src/components/navigator/menu/RoomControlMenu.tsx
@@ -1,7 +1,19 @@
-import { LeaveRoomDialog } from "@cb/components/dialog/LeaveRoomDialog";
+import { baseButtonClassName } from "@cb/components/dialog/RoomDialog";
 import { CopyIcon, LeaveIcon, SignOutIcon } from "@cb/components/icons";
 import { useSignOut } from "@cb/hooks/auth";
+import { Button } from "@cb/lib/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@cb/lib/components/ui/dialog";
 import { RoomStatus, useRoom } from "@cb/store";
+import { throttle } from "lodash";
+import React from "react";
 import { _AppControlMenu } from "./AppControlMenu";
 import { DropdownMenuItem } from "./DropdownMenuItem";
 import { Menu } from "./Menu";
@@ -11,33 +23,69 @@ export const RoomControlMenu = () => {
   const signout = useSignOut();
   const copyRoomId = useCopyRoomId();
 
+  const leave = useRoom((state) => state.actions.room.leave);
+
+  const leaveRoomThrottled = React.useMemo(() => {
+    return throttle((event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation?.();
+      leave();
+    }, 1000);
+  }, [leave]);
+
   return (
-    <Menu>
-      {roomStatus === RoomStatus.IN_ROOM && (
-        <>
-          <DropdownMenuItem onSelect={() => copyRoomId()}>
-            <span className="flex items-center gap-2">
-              <CopyIcon /> Copy Room ID
-            </span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-            <LeaveRoomDialog
-              customTrigger
-              node={
+    <Dialog>
+      <Menu>
+        {roomStatus === RoomStatus.IN_ROOM && (
+          <>
+            <DropdownMenuItem onSelect={() => copyRoomId()}>
+              <span className="flex items-center gap-2">
+                <CopyIcon /> Copy Room ID
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <DialogTrigger>
                 <span className="flex items-center gap-2">
                   <LeaveIcon /> Leave Room
                 </span>
-              }
-            />
-          </DropdownMenuItem>
-        </>
-      )}
-      <DropdownMenuItem onSelect={signout}>
-        <span className="flex items-center gap-2">
-          <SignOutIcon /> <span>Sign Out</span>
-        </span>
-      </DropdownMenuItem>
-      <_AppControlMenu />
-    </Menu>
+              </DialogTrigger>
+            </DropdownMenuItem>
+          </>
+        )}
+        <DropdownMenuItem onSelect={signout}>
+          <span className="flex items-center gap-2">
+            <SignOutIcon /> <span>Sign Out</span>
+          </span>
+        </DropdownMenuItem>
+        <_AppControlMenu />
+      </Menu>
+
+      <DialogContent className={cn("bg-primary")}>
+        <DialogHeader>
+          <DialogTitle className={cn("text-left text-xl font-semibold")}>
+            {"Leave Room"}
+          </DialogTitle>
+          <DialogDescription className={cn("text-left text-base font-medium")}>
+            {
+              "You will be disconnected, and you may not be able to rejoin unless invited again."
+            }
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex w-full items-center justify-end gap-2 self-end">
+          <DialogClose asChild>
+            <Button
+              className={baseButtonClassName}
+              onClick={leaveRoomThrottled}
+            >
+              <span className="text-sm font-medium">Yes</span>
+            </Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button className={baseButtonClassName}>
+              <span className="text-sm font-medium">No</span>
+            </Button>
+          </DialogClose>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };


### PR DESCRIPTION
# Description
- Replace `<LeaveRoomDialog>` with a custom component, the purpose of which was to move every `Dialog`-related components except `<DialogTrigger>` outside of dropdown menu so that menu can close after user leaves the room.

## Screenshots


https://github.com/user-attachments/assets/642eccfd-9289-4df5-aae4-53363deeb928


## Test

Run `pnpm dev:1` then follows the steps in screenshots

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [ ] Create room and join room on at least 2 browsers
- [ ] Ensure that code and tests are correctly stream
- [ ] Verify that when reloading, user can automatically join the room

## Possible Downsides

- Right now, I made direct changes to the dropdown menu component, so right now there are 2 ways Dialog are implemented (the other being the way `<RoomDialog>` is implemented, where the `<DialogTrigger>` is also inside `<Dialog>`. I think this is tech debt? So maybe we should streamline how `<Dialog>` components should be used in the future.

## Additional Documentations
