### PR TITLE
Update types for question

### DIFF
--- a/extension/src/components/dialog/SelectProblemDialog.tsx
+++ b/extension/src/components/dialog/SelectProblemDialog.tsx
@@ -1,5 +1,5 @@
 import { QuestionSelectorPanel } from "@cb/components/panel/problem";
-import { windowMessager } from "@cb/services/window";
+import { useRoomActions } from "@cb/hooks/store";
 import { useHtml } from "@cb/store/htmlStore";
 import { RoomDialog, RoomDialogProps } from "./RoomDialog";
 
@@ -15,6 +15,8 @@ export const SelectProblemDialog = ({
   setOpen,
 }: SelectProblemDialog) => {
   const iframeActions = useHtml((state) => state.actions);
+  const { addQuestion } = useRoomActions();
+
   return (
     <RoomDialog
       trigger={{
@@ -41,8 +43,8 @@ export const SelectProblemDialog = ({
       title={{ node: "Select next problem" }}
     >
       <QuestionSelectorPanel
-        handleQuestionSelect={(question) => {
-          windowMessager.navigate({ url: question });
+        handleQuestionSelect={(url) => {
+          addQuestion(url);
           setOpen(false);
         }}
         filterQuestionIds={[]}

--- a/extension/src/services/controllers/RoomController.ts
+++ b/extension/src/services/controllers/RoomController.ts
@@ -180,7 +180,7 @@ export class RoomController {
     this.appStore = appStore;
   }
 
-  public async create(room: Pick<Room, "name" | "isPublic">) {
+  public async create(room: Pick<Room, "name" | "isPublic" | "questions">) {
     if (this.room != null) {
       return this.room;
     }

--- a/extension/src/services/db/firebase/index.ts
+++ b/extension/src/services/db/firebase/index.ts
@@ -113,7 +113,7 @@ const getUserRef = (roomId: string, username: string) =>
 export const firebaseDatabaseServiceImpl: DatabaseService = {
   room: {
     async create(room) {
-      const doc = { ...room, usernames: [], version: 0, questions: [] };
+      const doc = { ...room, usernames: [], version: 0 };
       const ref = await addDoc(getRoomRefs(), doc);
       return {
         id: ref.id,
@@ -129,6 +129,14 @@ export const firebaseDatabaseServiceImpl: DatabaseService = {
       return setDoc(
         getRoomRef(id),
         { usernames: arrayUnion(user), version: increment(1) },
+        { merge: true }
+      );
+    },
+
+    addQuestion(id, question) {
+      return setDoc(
+        getRoomRef(id),
+        { questions: arrayUnion(question) },
         { merge: true }
       );
     },

--- a/extension/src/services/graphql/metadata.ts
+++ b/extension/src/services/graphql/metadata.ts
@@ -1,23 +1,19 @@
-export type ProblemMeta = {
-  id: string;
-  title: string;
-  slug: string;
-  difficulty: string;
-  tags: string[];
-  url: string;
-};
+import { Question } from "@cb/types";
 
-export enum Code {
+export enum GetProblemMetadataBySlugServerCode {
   SUCCESS = "SUCCESS",
   NOT_FOUND = "NOT_FOUND",
   BAD_RESPONSE = "BAD_RESPONSE",
   NETWORK_ERROR = "NETWORK_ERROR",
 }
 
-export type MetaResult =
-  | { code: Code.SUCCESS; data: ProblemMeta }
+export type GetProblemMetadataBySlugServerResponse =
+  | { code: GetProblemMetadataBySlugServerCode.SUCCESS; data: Question }
   | {
-      code: Code.NOT_FOUND | Code.BAD_RESPONSE | Code.NETWORK_ERROR;
+      code:
+        | GetProblemMetadataBySlugServerCode.NOT_FOUND
+        | GetProblemMetadataBySlugServerCode.BAD_RESPONSE
+        | GetProblemMetadataBySlugServerCode.NETWORK_ERROR;
       message: string;
     };
 
@@ -36,7 +32,7 @@ query question($titleSlug: String!) {
 
 export async function getProblemMetaBySlugServer(
   slug: string
-): Promise<MetaResult> {
+): Promise<GetProblemMetadataBySlugServerResponse> {
   try {
     const r = await fetch(LC_GRAPHQL, {
       method: "POST",
@@ -48,17 +44,23 @@ export async function getProblemMetaBySlugServer(
     });
 
     if (!r.ok) {
-      return { code: Code.BAD_RESPONSE, message: `HTTP ${r.status}` };
+      return {
+        code: GetProblemMetadataBySlugServerCode.BAD_RESPONSE,
+        message: `HTTP ${r.status}`,
+      };
     }
 
     const json = await r.json().catch(() => null);
     const q = json?.data?.question;
     if (!q) {
-      return { code: Code.NOT_FOUND, message: "No question returned" };
+      return {
+        code: GetProblemMetadataBySlugServerCode.NOT_FOUND,
+        message: "No question returned",
+      };
     }
 
     return {
-      code: Code.SUCCESS,
+      code: GetProblemMetadataBySlugServerCode.SUCCESS,
       data: {
         id: q.questionFrontendId,
         title: q.title,
@@ -69,6 +71,9 @@ export async function getProblemMetaBySlugServer(
       },
     };
   } catch (e: any) {
-    return { code: Code.NETWORK_ERROR, message: String(e?.message ?? e) };
+    return {
+      code: GetProblemMetadataBySlugServerCode.NETWORK_ERROR,
+      message: String(e?.message ?? e),
+    };
   }
 }

--- a/extension/src/store/roomStore.ts
+++ b/extension/src/store/roomStore.ts
@@ -2,7 +2,12 @@ import { DOM } from "@cb/constants";
 import { getOrCreateControllers } from "@cb/services";
 import background, { BackgroundProxy } from "@cb/services/background";
 import { RoomJoinCode } from "@cb/services/controllers/RoomController";
-import { BoundStore, Id, PeerMessage, PeerState } from "@cb/types";
+import {
+  getProblemMetaBySlugServer,
+  GetProblemMetadataBySlugServerCode,
+} from "@cb/services/graphql/metadata";
+import { windowMessager } from "@cb/services/window";
+import { BoundStore, Id, PeerMessage, PeerState, Question } from "@cb/types";
 import { ExtractMessage, Identifiable, MessagePayload } from "@cb/types/utils";
 import { getSelectedPeer } from "@cb/utils/peers";
 import { groupTestCases } from "@cb/utils/string";
@@ -26,16 +31,24 @@ interface UpdatePeerArgs extends Omit<PeerState, "tests"> {
 
 interface RoomState {
   status: RoomStatus;
-  room?: Identifiable<{ name: string; isPublic: boolean }>;
+  room?: Identifiable<{
+    name: string;
+    isPublic: boolean;
+    questions: Question[];
+  }>;
   peers: Record<Id, PeerState>;
 }
 
 interface RoomAction {
   room: {
-    create: (args: Omit<NonNullable<RoomState["room"]>, "id">) => Promise<void>;
+    create: (
+      args: Omit<NonNullable<RoomState["room"]>, "id" | "questions">
+    ) => Promise<void>;
     join: (id: Id) => Promise<void>;
     leave: () => Promise<void>;
     loading: () => void;
+    addQuestion: (url: string) => Promise<void>;
+    updateRoomStoreQuestion: (question: Question) => void;
   };
   peers: {
     update: (id: Id, peer: Partial<UpdatePeerArgs>) => Promise<void>;
@@ -65,9 +78,20 @@ const createRoomStore = (
             create: async (args) => {
               try {
                 get().actions.room.loading();
-                const room = await getOrCreateControllers().room.create(args);
+                const metadata = await getProblemMetaBySlugServer(
+                  getQuestionIdFromUrl(window.location.href)
+                );
+                if (
+                  metadata.code !== GetProblemMetadataBySlugServerCode.SUCCESS
+                ) {
+                  throw new Error(`Graphql metadata errors ${metadata}`);
+                }
+                const room = await getOrCreateControllers().room.create({
+                  ...args,
+                  questions: [metadata.data],
+                });
                 const { id, name, isPublic } = room.getRoom();
-                setRoom({ id, name, isPublic });
+                setRoom({ id, name, isPublic, questions: [] });
               } catch (error) {
                 toast.error("Failed to create room. Please try again.");
                 console.error("Failed to create room", error);
@@ -81,8 +105,8 @@ const createRoomStore = (
                 get().actions.room.loading();
                 const response = await getOrCreateControllers().room.join(id);
                 if (response.code === RoomJoinCode.SUCCESS) {
-                  const { name, isPublic } = response.data.getRoom();
-                  setRoom({ id, name, isPublic });
+                  const { name, isPublic, questions } = response.data.getRoom();
+                  setRoom({ id, name, isPublic, questions });
                 } else {
                   if (response.code === RoomJoinCode.NOT_EXISTS) {
                     toast.error("Room ID is invalid. Please try again.");
@@ -118,6 +142,31 @@ const createRoomStore = (
               set((state) => {
                 state.status = RoomStatus.LOADING;
               }),
+            addQuestion: async (url) => {
+              const metadata = await getProblemMetaBySlugServer(
+                getQuestionIdFromUrl(url)
+              );
+              if (
+                metadata.code !== GetProblemMetadataBySlugServerCode.SUCCESS
+              ) {
+                console.error("Failed to fetch graphql metadata", metadata);
+                toast.error("Failed to select next problem. Please try again");
+                return;
+              }
+              get().actions.room.updateRoomStoreQuestion(metadata.data);
+              windowMessager.navigate({ url });
+            },
+            updateRoomStoreQuestion(question) {
+              // todo(nickbar01234): We need a timestamp on question so the ordering is stable.
+              set((state) => {
+                if (
+                  state.room != undefined &&
+                  !state.room.questions.includes(question)
+                ) {
+                  state.room.questions.push(question);
+                }
+              });
+            },
           },
           peers: {
             update: async (id, peer) => {

--- a/extension/src/types/db.ts
+++ b/extension/src/types/db.ts
@@ -47,12 +47,21 @@ export interface Negotiation {
   message: NegotiationMessage;
 }
 
+export interface Question {
+  id: string;
+  title: string;
+  slug: string;
+  difficulty: "Easy" | "Medium" | "Hard";
+  tags: string[];
+  url: string;
+}
+
 export interface Room {
   usernames: User[];
   version: Version;
   isPublic: boolean;
   name: string;
-  questions: string[];
+  questions: Question[];
 }
 
 export type ObserverDocumentCallback<T> = {
@@ -81,10 +90,13 @@ interface DatabaseRoomObserver {
 }
 
 interface DatabaseRoomService {
-  create(room: Pick<Room, "name" | "isPublic">): Promise<Identifiable<Room>>;
+  create(
+    room: Pick<Room, "name" | "isPublic" | "questions">
+  ): Promise<Identifiable<Room>>;
   get(id: Id): Promise<Room | undefined>;
   addUser(id: Id, user: User): Promise<void>;
   removeUser(id: Id, user: User): Promise<void>;
+  addQuestion(id: Id, question: Question): Promise<void>;
   addNegotiation(id: Id, data: Negotiation): Promise<void>;
 
   getUser(roomId: Id, username: User): Promise<UserProgress | undefined>;


### PR DESCRIPTION
# Description

Previously, `questions[]` internally is only slug. This means that each peer independently need to refetch the metadata, leading to redundant work. We want to reduce load on Leetcode as much as possible to avoid issues like Cloudflare. We can consider moving the metadata to a separate collection, since we don't expect that they change.

## Test

When creating room, navigate to `http://127.0.0.1:3000/firestore/default/data/rooms/` to observe the updates to questions.

## Checklist

If you're making changes to the extension, please run through the following checklist to make sure that we don't have
any regressions. Note that we plan to add integration tests in the future!

- [ ] Create room and join room on at least 2 browsers
- [ ] Ensure that code and tests are correctly stream
- [ ] Verify that when reloading, user can automatically join the room

## Possible Downsides

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
